### PR TITLE
Fix formatting of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ LXC 1.1 in which case it should work automatically, or otherwise, copy
 the lxc.mount.hook file (once built) from this tree to
 /usr/share/lxc/hooks/lxcfs, make sure it is executable, then add the
 following two lines to your container configuration:
-
+```
 lxc.autodev = 1
 lxc.kmsg = 0
 lxc.include = /usr/share/lxcfs/00-lxc.conf
+```


### PR DESCRIPTION
They were all being shown in a single line, Now they're formatted as a codeblock
Signed-off-by: Anees Iqbal <aneesiqbalbhatti@gmail.com>