### PR TITLE
add cache for proc file,  for support multiple read

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,11 @@ lxcfs.1: lxcfs lxcfs.man.add
 	$(HELP2MAN) -n "Set up cgroup fs for containers" --no-discard-stderr -s 1 -I lxcfs.man.add -N ./lxcfs > lxcfs.1
 endif
 
+TEST_READ: tests/test-read.c
+	$(CC) -o tests/test-read tests/test-read.c
+
+tests: TEST_READ
+
 distclean:
 	rm -rf .deps/ \
 		INSTALL \

--- a/lxcfs.c
+++ b/lxcfs.c
@@ -43,6 +43,25 @@ struct lxcfs_state {
 };
 #define LXCFS_DATA ((struct lxcfs_state *) fuse_get_context()->private_data)
 
+#define MAX_DATA_BUF_SIZE 65536 /*64Kb should be enough*/
+
+struct file_cache {
+	size_t max_size;
+	size_t actual_size;
+	char *buf;
+};
+
+enum file_name {
+	FILE_MEMINFO   = 0,
+	FILE_CPUINFO   = 1,
+	FILE_UPTIME    = 2,
+	FILE_STAT      = 3,
+	FILE_DISKSTATS = 4,
+	NO_USED_FILE= 5, 
+};
+
+struct file_cache caches[NO_USED_FILE];
+
 /*
  * TODO - return value should denote whether child exited with failure
  * so callers can return errors.  Esp read/write of tasks and cgroup.procs
@@ -1470,10 +1489,18 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 	unsigned long memlimit = 0, memusage = 0, cached = 0, hosttotal = 0;
 	char *line = NULL;
 	size_t linelen = 0, total_len = 0;
+	char *cache = caches[FILE_MEMINFO].buf;
+	size_t cache_size = MAX_DATA_BUF_SIZE;
 	FILE *f;
 
-	if (offset)
-		return -EINVAL;
+	if (offset){
+		if (offset > caches[FILE_MEMINFO].actual_size)
+			return -EINVAL;
+		int left = caches[FILE_MEMINFO].actual_size - offset;
+		total_len = left > size ? size: left;
+		memcpy(buf, cache + offset, total_len);
+		return total_len;
+	}
 
 	if (!cg)
 		return 0;
@@ -1522,11 +1549,15 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 			printme = lbuf;
 		} else
 			printme = line;
-		l = snprintf(buf, size, "%s", printme);
-		buf += l;
-		size -= l;
+		l = snprintf(cache, cache_size, "%s", printme);
+		cache += l;
+		cache_size -= l;
 		total_len += l;
 	}
+
+	caches[FILE_MEMINFO].actual_size = total_len;
+	if (total_len > size ) total_len = size;
+	memcpy(buf, caches[FILE_MEMINFO].buf, total_len);
 
 	fclose(f);
 	free(line);
@@ -1619,10 +1650,18 @@ static int proc_cpuinfo_read(char *buf, size_t size, off_t offset,
 	size_t linelen = 0, total_len = 0;
 	bool am_printing = false;
 	int curcpu = -1;
+	char *cache = caches[FILE_CPUINFO].buf;
+	size_t cache_size = MAX_DATA_BUF_SIZE;
 	FILE *f;
 
-	if (offset)
-		return -EINVAL;
+	if (offset){
+		if (offset > caches[FILE_CPUINFO].actual_size)
+			return -EINVAL;
+		int left = caches[FILE_CPUINFO].actual_size - offset;
+		total_len = left > size ? size: left;
+		memcpy(buf, cache + offset, total_len);
+		return total_len;	
+	}
 
 	if (!cg)
 		return 0;
@@ -1641,20 +1680,38 @@ static int proc_cpuinfo_read(char *buf, size_t size, off_t offset,
 			am_printing = cpuline_in_cpuset(line, cpuset);
 			if (am_printing) {
 				curcpu ++;
-				l = snprintf(buf, size, "processor	: %d\n", curcpu);
-				buf += l;
-				size -= l;
-				total_len += l;
+				l = snprintf(cache, cache_size, "processor	: %d\n", curcpu);
+				if (l < cache_size) {
+					cache += l;
+					cache_size -= l;
+					total_len += l;
+				} else {
+					cache += cache_size;
+					total_len += cache_size;
+					cache_size = 0;
+					break;
+				}
 			}
 			continue;
 		}
 		if (am_printing) {
-			l = snprintf(buf, size, "%s", line);
-			buf += l;
-			size -= l;
-			total_len += l;
+			l = snprintf(cache, cache_size, "%s", line);
+			if (l < cache_size) {
+				cache += l;
+				cache_size -= l;
+				total_len += l;
+			} else {
+				cache += cache_size;
+				total_len += cache_size;
+				cache_size = 0;
+				break;
+			}
 		}
 	}
+
+	caches[FILE_CPUINFO].actual_size = total_len;
+	if (total_len > size ) total_len = size;
+	memcpy(buf, caches[FILE_CPUINFO].buf, total_len);
 
 	fclose(f);
 	free(line);
@@ -1670,10 +1727,24 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 	char *line = NULL;
 	size_t linelen = 0, total_len = 0;
 	int curcpu = -1; /* cpu numbering starts at 0 */
+ 	unsigned long user = 0, nice = 0, system = 0, idle = 0, iowait = 0, irq = 0, softirq = 0, steal = 0, guest = 0;
+ 	unsigned long user_sum = 0, nice_sum = 0, system_sum = 0, idle_sum = 0, iowait_sum = 0,
+ 					irq_sum = 0, softirq_sum = 0, steal_sum = 0, guest_sum = 0;
+#define CPUALL_MAX_SIZE 256
+	char cpuall[CPUALL_MAX_SIZE];
+	/* reserve for cpu all */
+	char *cache = caches[FILE_STAT].buf + CPUALL_MAX_SIZE;
+	size_t cache_size = MAX_DATA_BUF_SIZE - CPUALL_MAX_SIZE;
 	FILE *f;
 
-	if (offset)
-		return -EINVAL;
+	if (offset){
+		if (offset > caches[FILE_STAT].actual_size)
+			return -EINVAL;
+		int left = caches[FILE_STAT].actual_size - offset;
+		total_len = left > size ? size: left;
+		memcpy(buf, cache + offset, total_len);
+		return total_len;
+	}
 
 	if (!cg)
 		return 0;
@@ -1685,6 +1756,12 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 	f = fopen("/proc/stat", "r");
 	if (!f)
 		return 0;
+	
+	/* skip first line */
+	if (getline(&line, &linelen, f) < 0) {
+		fprintf(stderr, "proc_stat_read read failed\n");
+		goto out;
+	}
 
 	while (getline(&line, &linelen, f) != -1) {
 		size_t l;
@@ -1694,11 +1771,19 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 
 		if (sscanf(line, "cpu%9[^ ]", cpu_char) != 1) {
 			/* not a ^cpuN line containing a number N, just print it */
-			l = snprintf(buf, size, "%s", line);
-			buf += l;
-			size -= l;
-			total_len += l;
-			continue;
+			l = snprintf(cache, cache_size, "%s", line);
+			if (l < cache_size) {
+				cache += l;
+				cache_size -= l;
+				total_len += l;
+				continue;
+			} else {
+				/* no more space, skip */
+				cache += cache_size;
+				total_len += cache_size;
+				cache_size = 0;
+				break;
+			}
 		}
 
 		if (sscanf(cpu_char, "%d", &cpu) != 1)
@@ -1710,12 +1795,45 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 		c = strchr(line, ' ');
 		if (!c)
 			continue;
-		l = snprintf(buf, size, "cpu%d %s", curcpu, c);
-		buf += l;
-		size -= l;
+		l = snprintf(cache, cache_size, "cpu%d %s", curcpu, c);
+		cache += l;
+		cache_size -= l;
 		total_len += l;
+
+		if (sscanf(line, "%*s %lu %lu %lu %lu %lu %lu %lu %lu %lu", &user, &nice, &system, &idle, &iowait, &irq,
+			&softirq, &steal, &guest) != 9)
+			continue;
+		user_sum += user;
+		nice_sum += nice;
+		system_sum += system;
+		idle_sum += idle;
+		iowait_sum += iowait;
+		irq_sum += irq;
+		softirq_sum += softirq;
+		steal_sum += steal;
+		guest_sum += guest;
 	}
 
+	cache = caches[FILE_STAT].buf;
+	int cpuall_len = snprintf(cpuall, CPUALL_MAX_SIZE, "%s %lu %lu %lu %lu %lu %lu %lu %lu %lu\n", 
+ 		"cpu ", user_sum, nice_sum, system_sum, idle_sum, iowait_sum, irq_sum, softirq_sum, steal_sum, guest_sum);
+	if (cpuall_len > 0 && cpuall_len < CPUALL_MAX_SIZE){
+		memcpy(cache, cpuall, cpuall_len);
+		cache += cpuall_len;	
+	}else{
+		/* shouldn't happen */
+		fprintf(stderr, "proc_stat_read copy cpuall failed, cpuall_len=%d\n", cpuall_len);
+		cpuall_len = 0;
+	}
+
+	memmove(cache, caches[FILE_STAT].buf + CPUALL_MAX_SIZE, total_len);
+	total_len += cpuall_len;
+	caches[FILE_STAT].actual_size = total_len;
+	if (total_len > size ) total_len = size;
+
+	memcpy(buf, caches[FILE_STAT].buf, total_len);
+
+out:
 	fclose(f);
 	free(line);
 	return total_len;
@@ -1862,10 +1980,17 @@ static int proc_uptime_read(char *buf, size_t size, off_t offset,
 	struct fuse_context *fc = fuse_get_context();
 	long int reaperage = getreaperage(fc->pid);;
 	long int idletime = getprocidle();
+	size_t total_len = 0;
 
-	if (offset)
-		return -EINVAL;
-	return snprintf(buf, size, "%ld %ld\n", reaperage, idletime);
+	if (offset){
+		if (offset > caches[FILE_UPTIME].actual_size)
+			return -EINVAL;
+		return 0;
+	}
+
+	total_len = snprintf(buf, size, "%ld %ld\n", reaperage, idletime);
+	caches[FILE_UPTIME].actual_size = total_len;
+	return total_len;
 }
 
 static int proc_diskstats_read(char *buf, size_t size, off_t offset,
@@ -1888,8 +2013,11 @@ static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 	int i = 0;
 	FILE *f;
 
-	if (offset)
-		return -EINVAL;
+	if (offset){
+		if (offset > caches[FILE_DISKSTATS].actual_size)
+			return -EINVAL;
+		return 0;
+	}
 
 	if (!cg)
 		return 0;
@@ -1958,6 +2086,8 @@ static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 		total_len += l;
 	}
 
+	caches[FILE_DISKSTATS].actual_size = total_len;
+
 	fclose(f);
 	free(line);
 	return total_len;
@@ -1994,18 +2124,23 @@ static int proc_getattr(const char *path, struct stat *sb)
 		sb->st_nlink = 2;
 		return 0;
 	}
-	if (strcmp(path, "/proc/meminfo") == 0 ||
-			strcmp(path, "/proc/cpuinfo") == 0 ||
-			strcmp(path, "/proc/uptime") == 0 ||
-			strcmp(path, "/proc/stat") == 0 ||
-			strcmp(path, "/proc/diskstats") == 0) {
-		sb->st_size = get_procfile_size(path);
-		sb->st_mode = S_IFREG | 00444;
-		sb->st_nlink = 1;
-		return 0;
+	if (strcmp(path, "/proc/meminfo") == 0) {
+		caches[FILE_MEMINFO].max_size = caches[FILE_MEMINFO].actual_size = sb->st_size = get_procfile_size(path);
+	}else if(strcmp(path, "/proc/cpuinfo") == 0){
+		caches[FILE_CPUINFO].max_size = caches[FILE_CPUINFO].actual_size = sb->st_size = get_procfile_size(path);
+	}else if(strcmp(path, "/proc/uptime") == 0){
+		caches[FILE_UPTIME].max_size = caches[FILE_UPTIME].actual_size = sb->st_size = get_procfile_size(path);
+	}else if(strcmp(path, "/proc/stat") == 0){
+		caches[FILE_STAT].max_size = caches[FILE_STAT].actual_size = sb->st_size = get_procfile_size(path);
+	}else if(strcmp(path, "/proc/diskstats") == 0) {
+		caches[FILE_DISKSTATS].max_size = caches[FILE_DISKSTATS].actual_size = sb->st_size = get_procfile_size(path);
+	}else{
+		return -ENOENT;
 	}
+	sb->st_mode = S_IFREG | 00444;
+	sb->st_nlink = 1;
 
-	return -ENOENT;
+	return 0;
 }
 
 static int proc_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset,
@@ -2270,6 +2405,11 @@ int main(int argc, char *argv[])
 	d = malloc(sizeof(*d));
 	if (!d)
 		return -1;
+
+	memset(caches, 0, sizeof(caches));
+	for ( int i = 0; i < NO_USED_FILE; i ++){
+		caches[i].buf = (char *) malloc(MAX_DATA_BUF_SIZE);	
+	}
 
 	if (!cgm_escape_cgroup())
 		fprintf(stderr, "WARNING: failed to escape to root cgroup\n");

--- a/tests/test-read.c
+++ b/tests/test-read.c
@@ -1,0 +1,47 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define BUFSIZE 1025
+char buf[BUFSIZE];
+
+int read_count = 2;
+
+int main(int argc, char *argv[]){
+	if(argc < 3){
+		fprintf(stderr, "usage: %s <file> <count> [buffer|direct]\n", argv[0]);
+		exit(1);
+	}
+	char *file = argv[1];
+	read_count = atoi(argv[2]);
+	int ret = 0,sum = 0, i = 0, fd = -1;
+	if(argc == 4 && strncmp(argv[3], "direct",6) == 0)
+		fd = open(file, O_RDONLY|O_DIRECT);
+	else
+		fd = open(file, O_RDONLY);
+	
+	while(i++ < read_count){
+		memset(buf, 0, BUFSIZE);
+		ret = read(fd, buf, BUFSIZE-1);
+		if(ret > 0){
+			write(STDOUT_FILENO, buf, ret);
+			sum += ret;
+		}else if(ret == 0){
+			printf("======read end======\n");
+			break;
+		}else{
+			printf("error:%d\n", errno);
+			break;
+		}
+		sleep(1);
+	}
+	printf("======read sum: %d======\n", sum);
+	close(fd);
+	return 0;
+}

--- a/tests/test_read_proc.sh
+++ b/tests/test_read_proc.sh
@@ -1,0 +1,32 @@
+#/bin/bash
+#./lxcfs -s -f -d -o allow_other -o direct_io /var/lib/lxcfs
+
+red_c() {
+     echo -e $2 "\e[31;1m${1}\e[0m"
+}
+DIR=/var/lib/lxcfs
+
+if ! mountpoint -q $DIR; then
+    echo "lxcfs isn't mounted on /var/lib/lxcfs"
+    exit 1
+fi
+
+
+PWD=`pwd`
+COUNT=3
+
+for i in test-read
+do
+	BIN=$PWD/$i
+
+	red_c "$BIN test cpuinfo"
+	$BIN $DIR/proc/cpuinfo $COUNT
+
+	red_c "$BIN test stat"
+	$BIN $DIR/proc/stat $COUNT
+	
+	red_c "$BIN test meminfo"
+	$BIN $DIR/proc/meminfo $COUNT
+	
+done
+exit 0


### PR DESCRIPTION
Add cache for proc file.
Save all data to cache when first read, and then return data from cache for the next read for the same opened fd.

Some tools like cat, with buffered IO, if result is too long, will cause kernel read more than once, and lxcfs will return INVAL error：

```
In container:
#strace -f cat /proc/cpuinfo
…
open("/proc/cpuinfo", O_RDONLY)         = 3
fstat(3, {st_mode=S_IFREG|0444, st_size=21786, ...}) = 0
read(3, "processor\t: 0\nvendor_id\t: Genuin"..., 32768) = 7264
write(1, "processor\t: 0\nvendor_id\t: Genuin"..., 7264processor        : 0) = 7264
read(3, 0xf81000, 32768)                = -1 EINVAL (Invalid argument)
write(2, "cat: ", 5cat: )                    = 5
write(2, "/proc/cpuinfo", 13/proc/cpuinfo)           = 13
write(2, ": Invalid argument", 18: Invalid argument)      = 18
```

In addition, cache can also support DIRECT IO.

Signed-off-by: Ye Yin <eyniy@qq.com>