### PR TITLE
Implement SwapTotal and SwapFree support for /proc/meminfo

### DIFF
--- a/lxcfs.c
+++ b/lxcfs.c
@@ -1883,8 +1883,10 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 	struct fuse_context *fc = fuse_get_context();
 	struct file_info *d = (struct file_info *)fi->fh;
 	char *cg;
-	char *memusage_str = NULL, *memstat_str = NULL;
-	unsigned long memlimit = 0, memusage = 0, cached = 0, hosttotal = 0;
+	char *memusage_str = NULL, *memstat_str = NULL,
+		*memswlimit_str = NULL, *memswusage_str = NULL;
+	unsigned long memlimit = 0, memusage = 0, memswlimit = 0, memswusage = 0,
+		cached = 0, hosttotal = 0;
 	char *line = NULL;
 	size_t linelen = 0, total_len = 0, rv = 0;
 	char *cache = d->buf;
@@ -1911,6 +1913,18 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 		goto err;
 	if (!cgm_get_value("memory", cg, "memory.stat", &memstat_str))
 		goto err;
+
+	// Following values are allowed to fail, because swapaccount might be turned
+	// off for current kernel
+	if(cgm_get_value("memory", cg, "memory.memsw.limit_in_bytes", &memswlimit_str) &&
+		cgm_get_value("memory", cg, "memory.memsw.usage_in_bytes", &memswusage_str))
+	{
+		memswlimit = strtoul(memswlimit_str, NULL, 10);
+		memswusage = strtoul(memswusage_str, NULL, 10);
+		memswlimit /= 1024;
+		memswusage /= 1024;
+	}
+	
 	memusage = strtoul(memusage_str, NULL, 10);
 	memlimit /= 1024;
 	memusage /= 1024;
@@ -1936,6 +1950,13 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 			printme = lbuf;
 		} else if (startswith(line, "MemAvailable:")) {
 			snprintf(lbuf, 100, "MemAvailable:   %8lu kB\n", memlimit - memusage);
+			printme = lbuf;
+		} else if (startswith(line, "SwapTotal:") && memswlimit > 0) {
+			snprintf(lbuf, 100, "SwapTotal:      %8lu kB\n", memswlimit - memlimit);
+			printme = lbuf;
+		} else if (startswith(line, "SwapFree:") && memswlimit > 0 && memswusage > 0) {
+			snprintf(lbuf, 100, "SwapFree:       %8lu kB\n", 
+				(memswlimit - memlimit) - (memswusage - memusage));
 			printme = lbuf;
 		} else if (startswith(line, "Buffers:")) {
 			snprintf(lbuf, 100, "Buffers:        %8lu kB\n", 0UL);
@@ -1979,6 +2000,8 @@ err:
 	free(line);
 	free(cg);
 	free(memusage_str);
+	free(memswlimit_str);
+	free(memswusage_str);
 	free(memstat_str);
 	return rv;
 }


### PR DESCRIPTION
This patch implements SwapTotal and SwapFree support for /proc/meminfo so that programs like htop and top can see the correct swap values inside an LXC container.

In order to show the correct values kernel needs to have swapaccount=1. If however this is not the case, we will not modify the values in any way showing the host's swap values for the container.

I have tested this patch on Ubuntu 15.10 and it is working as expected.