### PR TITLE
cgroup idx not exceed 30 safety check interferes with normal operation

### DIFF
--- a/cgfs.c
+++ b/cgfs.c
@@ -141,7 +141,7 @@ static bool store_hierarchy(char *stridx, char *h)
 	int idx = atoi(stridx);
 	size_t needed_len = (idx + 1) * sizeof(char *);
 
-	if (idx < 0 || idx > 30) {
+	if (idx < 0) {
 		fprintf(stderr, "Error: corrupt /proc/self/cgroup\n");
 		return false;
 	}


### PR DESCRIPTION
in store_hierarchy(), /proc/self/cgroup is parsed up but if the idx number exceeds 30 we bomb out, thinking it's corrupt.  However on my system these are over 700:
```
$ cat /proc/self/cgroup
728:perf_event:/
727:net_prio:/
726:net_cls:/
725:freezer:/
724:devices:/
723:cpuset:/
722:cpuacct:/
721:cpu:/
720:blkio:/
```

this is probably an uncommon situation resulting from the experimentation i'm doing with cgroups -- it seems every time the cgroup is created the index number increases -- but it really should work nonetheless (and does run fine if I remove the check), there's nothing wrong/corrupt about my system in this state.  Indeed, the value could be in the thousands probably or more and still be valid.