### PR TITLE
Don't hardcode strings in testsuites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ share/lxc.reboot.hook
 tests/cpusetrange
 tests/test-read
 lxcfs_mkdir
+tests/test_syscalls
 *.o
 pam/.dirstamp
 pam/pam_cgfs_la-pam_cgfs.lo

--- a/tests/test_cgroup
+++ b/tests/test_cgroup
@@ -1,6 +1,7 @@
 #!/bin/sh -eux
 
 PASS=0
+UUID=$(uuidgen)
 
 cleanup() {
     [ "$PASS" = "1" ] || (echo FAIL && exit 1)
@@ -27,27 +28,27 @@ cpupath=/sys/fs/cgroup/cpuset/${initcpuset}
 mempath=/sys/fs/cgroup/memory/${initmemory}
 frzpath=/sys/fs/cgroup/freezer/${initfreezer}
 
-rmdir ${cpupath}/lxcfs_test_cgroup || true
-rmdir ${mempath}/lxcfs_test_cgroup || true
-rmdir ${frzpath}/lxcfs_test_cgroup || true
-mkdir ${cpupath}/lxcfs_test_cgroup
-mkdir ${mempath}/lxcfs_test_cgroup
-mkdir ${frzpath}/lxcfs_test_cgroup
+rmdir ${cpupath}/${UUID} || true
+rmdir ${mempath}/${UUID} || true
+rmdir ${frzpath}/${UUID} || true
+mkdir ${cpupath}/${UUID}
+mkdir ${mempath}/${UUID}
+mkdir ${frzpath}/${UUID}
 
 # Check that the fs is readable
 for p in ${mempath} ${frzpath} ${cpupath}; do
 	find ${p} > /dev/null
-	echo 1 > ${p}/lxcfs_test_cgroup/tasks
+	echo 1 > ${p}/${UUID}/tasks
 done
 
 # set values though lxcfs
-echo $((1024*1024)) > ${LXCFSDIR}/cgroup/memory/${initmemory}/lxcfs_test_cgroup/memory.limit_in_bytes
-echo 0 > ${LXCFSDIR}/cgroup/cpuset/${initcpuset}/lxcfs_test_cgroup/cpuset.cpus
+echo $((1024*1024)) > ${LXCFSDIR}/cgroup/memory/${initmemory}/${UUID}/memory.limit_in_bytes
+echo 0 > ${LXCFSDIR}/cgroup/cpuset/${initcpuset}/${UUID}/cpuset.cpus
 
 # and verify them through cgroupfs
-v=`cat $mempath/lxcfs_test_cgroup/memory.limit_in_bytes`
+v=`cat $mempath/${UUID}/memory.limit_in_bytes`
 [ "$v" = "$((1024*1024))" ]
-v=`cat ${cpupath}/lxcfs_test_cgroup/cpuset.cpus`
+v=`cat ${cpupath}/${UUID}/cpuset.cpus`
 [ "$v" = "0" ]
 
 PASS=1

--- a/tests/test_confinement.sh
+++ b/tests/test_confinement.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+UUID=$(uuidgen)
+
 [ $(id -u) -eq 0 ]
 
 d=$(mktemp -t -d tmp.XXX)
@@ -30,59 +32,59 @@ cgm create freezer x1
 cgm movepid freezer x1 1
 
 mount -t cgroup -o freezer freezer $d2
-sudo rmdir $d2/lxcfs_test_a1/lxcfs_test_a2 || true
-sudo rmdir $d2/lxcfs_test_a1 || true
+sudo rmdir $d2/${UUID}_a1/${UUID}_a2 || true
+sudo rmdir $d2/${UUID}_a1 || true
 
 echo "Making sure root cannot mkdir"
 bad=0
-mkdir $d/cgroup/freezer/lxcfs_test_a1 && bad=1
+mkdir $d/cgroup/freezer/${UUID}_a1 && bad=1
 if [ "${bad}" -eq 1 ]; then
 	false
 fi
 
 echo "Making sure root cannot rmdir"
-mkdir $d2/lxcfs_test_a1
-mkdir $d2/lxcfs_test_a1/lxcfs_test_a2
-rmdir $d/cgroup/freezer/lxcfs_test_a1 && bad=1
+mkdir $d2/${UUID}_a1
+mkdir $d2/${UUID}_a1/${UUID}_a2
+rmdir $d/cgroup/freezer/${UUID}_a1 && bad=1
 if [ "${bad}" -eq 1 ]; then
 	false
 fi
-[ -d $d2/lxcfs_test_a1 ]
-rmdir $d/cgroup/freezer/lxcfs_test_a1/lxcfs_test_a2 && bad=1
+[ -d $d2/${UUID}_a1 ]
+rmdir $d/cgroup/freezer/${UUID}_a1/${UUID}_a2 && bad=1
 if [ "${bad}" -eq 1 ]; then
 	false
 fi
-[ -d $d2/lxcfs_test_a1/lxcfs_test_a2 ]
+[ -d $d2/${UUID}_a1/${UUID}_a2 ]
 
 echo "Making sure root cannot read/write"
 sleep 200 &
 p=$!
-echo $p > $d/cgroup/freezer/lxcfs_test_a1/tasks && bad=1
+echo $p > $d/cgroup/freezer/${UUID}_a1/tasks && bad=1
 if [ "${bad}" -eq 1 ]; then
 	false
 fi
-cat $d/cgroup/freezer/lxcfs_test_a1/tasks && bad=1
+cat $d/cgroup/freezer/${UUID}_a1/tasks && bad=1
 if [ "${bad}" -eq 1 ]; then
 	false
 fi
-echo $p > $d/cgroup/freezer/lxcfs_test_a1/lxcfs_test_a2/tasks && bad=1
+echo $p > $d/cgroup/freezer/${UUID}_a1/${UUID}_a2/tasks && bad=1
 if [ "${bad}" -eq 1 ]; then
 	false
 fi
-cat $d/cgroup/freezer/lxcfs_test_a1/lxcfs_test_a2/tasks && bad=1
+cat $d/cgroup/freezer/${UUID}_a1/${UUID}_a2/tasks && bad=1
 if [ "${bad}" -eq 1 ]; then
 	false
 fi
 
 # make sure things like truncate and access don't leak info about
-# the /lxcfs_test_a1 cgroup which we shouldn't be able to reach
+# the /${UUID}_a1 cgroup which we shouldn't be able to reach
 echo "Testing other system calls"
-${dirname}/test_syscalls $d/cgroup/freezer/lxcfs_test_a1
-${dirname}/test_syscalls $d/cgroup/freezer/lxcfs_test_a1/lxcfs_test_a2
+${dirname}/test_syscalls $d/cgroup/freezer/${UUID}_a1
+${dirname}/test_syscalls $d/cgroup/freezer/${UUID}_a1/${UUID}_a2
 
 echo "Making sure root can act on descendents"
 mycg=$(cgm getpidcgroupabs freezer 1)
-newcg=${mycg}/lxcfs_test_a1
+newcg=${mycg}/${UUID}_a1
 rmdir $d2/$newcg || true  # cleanup previosu run
 mkdir $d/cgroup/freezer/$newcg
 echo $p > $d/cgroup/freezer/$newcg/tasks

--- a/tests/test_meminfo_hierarchy.sh
+++ b/tests/test_meminfo_hierarchy.sh
@@ -4,8 +4,8 @@ set -eux
 
 LXCFSDIR=${LXCFSDIR:-/var/lib/lxcfs}
 
-cg1=x1.$$
-cg2=x2.$$
+cg1=$(uuidgen).$$
+cg2=$(uuidgen).$$
 
 cleanup() {
 	if [ $FAILED -eq 1 ]; then

--- a/tests/test_read_proc.sh
+++ b/tests/test_read_proc.sh
@@ -24,9 +24,8 @@ do
 
 	red_c "$BIN test stat"
 	$BIN $DIR/proc/stat $COUNT
-	
+
 	red_c "$BIN test meminfo"
 	$BIN $DIR/proc/meminfo $COUNT
-	
 done
 exit 0


### PR DESCRIPTION
With this, we should be able to run more than one testsuite at once.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>