### PR TITLE
Add upstart and systemd init jobs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = tests share
+SUBDIRS = tests share config
 DIST_SUBDIRS = tests share
 
 AM_CFLAGS = -Wall -ggdb -D_GNU_SOURCE -DSBINDIR=\"$(SBINDIR)\" -pthread

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = init

--- a/config/init/Makefile.am
+++ b/config/init/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = systemd sysvinit upstart

--- a/config/init/systemd/Makefile.am
+++ b/config/init/systemd/Makefile.am
@@ -1,0 +1,16 @@
+EXTRA_DIST = lxcfs.service
+
+if INIT_SCRIPT_SYSTEMD
+SYSTEMD_UNIT_DIR = $(prefix)/lib/systemd/system
+
+install-systemd: lxcfs.service
+	$(MKDIR_P) $(DESTDIR)$(SYSTEMD_UNIT_DIR)
+	$(INSTALL_DATA) lxcfs.service $(DESTDIR)$(SYSTEMD_UNIT_DIR)/
+
+uninstall-systemd:
+	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/lxcfs.service
+	rmdir $(DESTDIR)$(SYSTEMD_UNIT_DIR) || :
+
+install-data-local: install-systemd
+uninstall-local: uninstall-systemd
+endif

--- a/config/init/systemd/lxcfs.service
+++ b/config/init/systemd/lxcfs.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=FUSE filesystem for LXC
+ConditionVirtualization=!container
+Before=lxc.service
+
+[Service]
+ExecStart=/usr/bin/lxcfs /var/lib/lxcfs/
+KillMode=process
+Restart=on-failure
+ExecStopPost=-/bin/fusermount -u /var/lib/lxcfs
+Delegate=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/config/init/sysvinit/Makefile.am
+++ b/config/init/sysvinit/Makefile.am
@@ -1,0 +1,14 @@
+EXTRA_DIST = lxcfs
+
+if INIT_SCRIPT_SYSV
+install-sysvinit: lxcfs
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/rc.d/init.d
+	$(INSTALL_SCRIPT) lxcfs $(DESTDIR)$(sysconfdir)/rc.d/init.d/lxcfs
+
+uninstall-sysvinit:
+	rm -f $(DESTDIR)$(sysconfdir)/rc.d/init.d/lxcfs
+	rmdir $(DESTDIR)$(sysconfdir)/rc.d/init.d || :
+
+install-data-local: install-sysvinit
+uninstall-local: uninstall-sysvinit
+endif

--- a/config/init/sysvinit/lxcfs.init
+++ b/config/init/sysvinit/lxcfs.init
@@ -1,0 +1,96 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Short-Description:    FUSE filesystem for LXC
+# Description:          FUSE filesystem for LXC
+# Provides:             lxcfs
+# Required-Start:       $remote_fs
+# Required-Stop:        $remote_fs
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+### END INIT INFO
+
+DAEMON=/usr/bin/lxcfs
+NAME=lxcfs
+DESC="FUSE filesystem for LXC"
+PIDFILE=/var/run/lxcfs.pid
+
+. /lib/lsb/init-functions
+
+test -f ${DAEMON} || exit 0
+
+set -e
+
+START="-m --start --quiet --pidfile ${PIDFILE} --name ${NAME} --startas $DAEMON --background"
+case "$1" in
+    start)
+        if init_is_upstart; then
+            exit 1
+        fi
+
+        # Don't start if bind-mounted from host
+        [ ! -d /var/lib/lxcfs/proc ] || exit 0
+
+        # Cleanup in case of crash
+        fusermount -u /var/lib/lxcfs 2> /dev/null || true
+        [ -L /etc/mtab ] || \
+            sed -i "/^lxcfs \/var\/lib\/lxcfs fuse.lxcfs/d" /etc/mtab
+
+        echo -n "Starting $DESC: "
+        if start-stop-daemon ${START} -- /var/lib/lxcfs >/dev/null 2>&1 ; then
+            echo "${NAME}."
+        else
+            if start-stop-daemon --test ${START} >/dev/null 2>&1; then
+                echo "(failed)."
+                exit 1
+            else
+                echo "${DAEMON} already running."
+                exit 0
+            fi
+        fi
+
+        exit 0
+    ;;
+
+    stop)
+        if init_is_upstart; then
+            exit 0
+        fi
+        echo -n "Stopping $DESC: "
+        if start-stop-daemon --stop --quiet --pidfile ${PIDFILE} \
+            --startas ${DAEMON} --retry 10 --name ${NAME} \
+            >/dev/null 2>&1 ; then
+                echo "${NAME}."
+        else
+            if start-stop-daemon --test ${START} >/dev/null 2>&1; then
+                echo "(not running)."
+                exit 0
+            else
+                echo "(failed)."
+                exit 1
+            fi
+        fi
+
+        exit 0
+    ;;
+
+    status)
+        if init_is_upstart; then
+            exit 0
+        fi
+        status_of_proc -p ${PIDFILE} "${DAEMON}" lxcfs
+    ;;
+
+    restart|force-reload)
+        if init_is_upstart; then
+            exit 1
+        fi
+        $0 stop
+        exec $0 start
+    ;;
+
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload}" 1>&2
+        exit 1
+    ;;
+esac

--- a/config/init/upstart/Makefile.am
+++ b/config/init/upstart/Makefile.am
@@ -1,0 +1,14 @@
+EXTRA_DIST = lxcfs.conf
+
+if INIT_SCRIPT_UPSTART
+install-upstart: lxcfs.conf
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/init/
+	$(INSTALL_DATA) lxcfs.conf $(DESTDIR)$(sysconfdir)/init/
+
+uninstall-upstart:
+	rm -f $(DESTDIR)$(sysconfdir)/init/lxcfs.conf
+	rmdir $(DESTDIR)$(sysconfdir)/init || :
+
+install-data-local: install-upstart
+uninstall-local: uninstall-upstart
+endif

--- a/config/init/upstart/lxcfs.conf
+++ b/config/init/upstart/lxcfs.conf
@@ -1,0 +1,20 @@
+description "FUSE filesystem for LXC"
+author "Stéphane Graber <stgraber@ubuntu.com>"
+
+start on starting lxc or cgmanager-ready
+stop on runlevel [06]
+
+respawn
+
+pre-start script
+    [ ! -d /var/lib/lxcfs/proc ] || { stop; exit 0; }
+end script
+
+exec /usr/bin/lxcfs /var/lib/lxcfs
+
+post-stop script
+    # Cleanup in case of crash
+    fusermount -u /var/lib/lxcfs 2> /dev/null || true
+    [ -L /etc/mtab ] || \
+        sed -i "/^lxcfs \/var\/lib\/lxcfs fuse.lxcfs/d" /etc/mtab
+end script

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,11 @@ AC_GNU_SOURCE
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
 	Makefile
+	config/Makefile
+	config/init/Makefile
+	config/init/systemd/Makefile
+	config/init/sysvinit/Makefile
+	config/init/upstart/Makefile
 	share/Makefile
 	share/00-lxcfs.conf
 	share/lxc.mount.hook
@@ -41,6 +46,108 @@ AS_AC_EXPAND(RUNTIME_PATH, "$with_runtime_path")
 AS_AC_EXPAND(LXCFSSHAREDIR, "$datarootdir/lxcfs")
 AS_AC_EXPAND(LXCCONFDIR, "$datarootdir/lxc/config/common.conf.d")
 AS_AC_EXPAND(LXCFSTARGETDIR, "$localstatedir/lib/lxcfs")
+
+# Detect the distribution. This is used for the default configuration and
+# for some distro-specific build options.
+AC_MSG_CHECKING([host distribution])
+AC_ARG_WITH(distro, AS_HELP_STRING([--with-distro=DISTRO], [Specify the Linux distribution to target: One of redhat, oracle, centos, fedora, suse, gentoo, debian, arch, slackware, paldo, openmandriva or pardus.]))
+if type lsb_release >/dev/null 2>&1 && test "z$with_distro" = "z"; then
+	with_distro=`lsb_release -is`
+fi
+if test "z$with_distro" = "z"; then
+	AC_CHECK_FILE(/etc/redhat-release,with_distro="redhat")
+	AC_CHECK_FILE(/etc/oracle-release,with_distro="oracle")
+	AC_CHECK_FILE(/etc/centos-release,with_distro="centos")
+	AC_CHECK_FILE(/etc/fedora-release,with_distro="fedora")
+	AC_CHECK_FILE(/etc/SuSE-release,with_distro="suse")
+	AC_CHECK_FILE(/etc/gentoo-release,with_distro="gentoo")
+	AC_CHECK_FILE(/etc/debian_version,with_distro="debian")
+	AC_CHECK_FILE(/etc/arch-release,with_distro="arch")
+	AC_CHECK_FILE(/etc/slackware-version,with_distro="slackware")
+	AC_CHECK_FILE(/etc/frugalware-release,with_distro="frugalware")
+	AC_CHECK_FILE(/etc/mandrakelinux-release, with_distro="openmandriva")
+	AC_CHECK_FILE(/etc/mandriva-release,with_distro="openmandriva")
+	AC_CHECK_FILE(/etc/pardus-release,with_distro="pardus")
+fi
+with_distro=`echo ${with_distro} | tr '[[:upper:]]' '[[:lower:]]'`
+
+if test "z$with_distro" = "z"; then
+	with_distro="unknown"
+fi
+case $with_distro in
+	ubuntu)
+		distroconf=default.conf.ubuntu
+		;;
+	redhat|centos|fedora|oracle|oracleserver)
+		distroconf=default.conf.libvirt
+		;;
+	*)
+		distroconf=default.conf.unknown
+		;;
+esac
+AC_MSG_RESULT([$with_distro])
+AM_CONDITIONAL([HAVE_DEBIAN], [test x"$with_distro" = "xdebian" -o x"$with_distro" = "xubuntu"])
+AM_CONDITIONAL([DISTRO_UBUNTU], [test "x$with_distro" = "xubuntu"])
+
+# Check for init system type
+AC_MSG_CHECKING([for init system type])
+AC_ARG_WITH([init-script],
+	    [AC_HELP_STRING([--with-init-script@<:@=TYPE@<:@,TYPE,...@:>@@:>@],
+			    [Type(s) of init script to install: bsd, openrc, sysvinit, systemd, upstart,
+			     distro @<:@default=distro@:>@])],[],[with_init_script=distro])
+case "$with_init_script" in
+	distro)
+		case $with_distro in
+			fedora)
+				init_script=systemd
+				;;
+			redhat|centos|oracle|oracleserver)
+				init_script=sysvinit
+				;;
+			debian)
+				init_script=upstart,systemd
+				;;
+			ubuntu)
+				init_script=upstart,systemd
+				;;
+			slackware)
+				echo -n "Warning: bsd init job not yet implemented"
+				init_script=
+				;;
+                        gentoo)
+				echo -n "Warning: openrc init job not yet implemented"
+				init_script=
+				;;
+			*)
+				echo -n "Linux distribution init system unknown."
+				init_script=
+				;;
+		esac
+		;;
+	*)
+		init_script=$with_init_script
+		;;
+esac
+
+# Check valid init systems were given, run in subshell so we don't mess up IFS
+(IFS="," ; for init_sys in $init_script;
+do
+	case "$init_sys" in
+		none|bsd|openrc|sysvinit|systemd|upstart)
+			;;
+		*)
+			exit 1
+			;;
+	esac
+done) || AC_MSG_ERROR([Unknown init system type in $init_script])
+
+AM_CONDITIONAL([INIT_SCRIPT_BSD], [echo "$init_script" |grep -q "bsd"])
+AM_CONDITIONAL([INIT_SCRIPT_OPENRC], [echo "$init_script" |grep -q "openrc"])
+AM_CONDITIONAL([INIT_SCRIPT_SYSV], [echo "$init_script" |grep -q "sysvinit"])
+AM_CONDITIONAL([INIT_SCRIPT_SYSTEMD], [echo "$init_script" |grep -q "systemd"])
+AM_CONDITIONAL([INIT_SCRIPT_UPSTART], [echo "$init_script" |grep -q "upstart"])
+AC_MSG_RESULT($init_script)
+
 
 AC_ARG_WITH(
 	[pamdir],


### PR DESCRIPTION
Mostly copied from the Ubuntu package.

Note someone still needs to write the bsd and gentoo init
scripts.  (You can look at the sysvinit jobs here and the
bsd+gentoo jobs in git://github.com/lxc/cgmanager for
inspiration).

Closes #71

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>