### PR TITLE
upstart: change how we decide to not run in a container

### DIFF
--- a/config/init/upstart/lxcfs.conf
+++ b/config/init/upstart/lxcfs.conf
@@ -1,14 +1,20 @@
 description "FUSE filesystem for LXC"
 author "Stéphane Graber <stgraber@ubuntu.com>"
 
-start on not-container and (starting lxc or runlevel [2345])
+start on starting lxc or starting lxd or runlevel [2345]
 stop on runlevel [06]
 
 respawn
 
+pre-start script
+    [ ! -e /run/container_type ] || { stop; exit 0; }
+end script
+
 exec /usr/bin/lxcfs /var/lib/lxcfs
 
 post-stop script
+    [ -e /run/container_type ] && exit
+
     # Cleanup in case of crash
     fusermount -u /var/lib/lxcfs 2> /dev/null || true
     [ -L /etc/mtab ] || \


### PR DESCRIPTION
Otherwise lxcfs keeps lxc from hitting state 'started', which
in turn blocks reboot/shutdown.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>