### PR TITLE
hook: Don't fail when root mountpoint is a symlink

### DIFF
--- a/share/lxc.mount.hook.in
+++ b/share/lxc.mount.hook.in
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+# We're dealing with mount entries, so expand any symlink
+LXC_ROOTFS_MOUNT=$(readlink -f ${LXC_ROOTFS_MOUNT}
+
 # /proc files
 if [ -d @LXCFSTARGETDIR@/proc/ ]; then
     for entry in @LXCFSTARGETDIR@/proc/*; do


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>