### PR TITLE
set mode 755 for $RUNTIME_PATH/lxcfs/controllers

### DIFF
--- a/lxcfs.c
+++ b/lxcfs.c
@@ -799,7 +799,7 @@ static bool umount_if_mounted(void)
 
 static bool setup_cgfs_dir(void)
 {
-	if (!mkdir_p(basedir, 0700)) {
+	if (!mkdir_p(basedir, 0755)) {
 		fprintf(stderr, "Failed to create lxcfs cgdir\n");
 		return false;
 	}
@@ -807,7 +807,7 @@ static bool setup_cgfs_dir(void)
 		fprintf(stderr, "Failed to clean up old lxcfs cgdir\n");
 		return false;
 	}
-	if (mount("tmpfs", basedir, "tmpfs", 0, "size=100000,mode=700") < 0) {
+	if (mount("tmpfs", basedir, "tmpfs", 0, "size=100000,mode=755") < 0) {
 		fprintf(stderr, "Failed to mount tmpfs for private controllers\n");
 		return false;
 	}


### PR DESCRIPTION
Let's set it to the same mode as /sys/fs/cgroup. Also, tools like Docker will
complain about not being able to stat /run/lxcfs/controllers when mode is set to
700.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>

(This should take care of docker/docker#20548.)