### PR TITLE
skip empty entries under /proc/self/cgroup

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -3951,6 +3951,14 @@ static void __attribute__((constructor)) collect_subsystems(void)
 			goto out;
 		*p2 = '\0';
 
+		/* With cgroupv2 /proc/self/cgroup can contain entries of the
+		 * form: 0::/ This will cause lxcfs to fail the cgroup mounts
+		 * because it parses out the empty string "" and later on passes
+		 * it to mount(). Let's skip such entries.
+		 */
+		if (!strcmp(p, ""))
+			continue;
+
 		if (!store_hierarchy(line, p))
 			goto out;
 	}

--- a/lxcfs.c
+++ b/lxcfs.c
@@ -859,6 +859,14 @@ static bool do_mount_cgroups(void)
 			goto out;
 		*p2 = '\0';
 
+		/* With cgroupv2 /proc/self/cgroup can contain entries of the
+		 * form: 0::/ This will cause lxcfs to fail the cgroup mounts
+		 * because it parses out the empty string "" and later on passes
+		 * it to mount(). Let's skip such entries.
+		 */
+		if (!strcmp(p, ""))
+			continue;
+
 		if (!do_mount_cgroup(p))
 			goto out;
 	}


### PR DESCRIPTION
If cgroupv2 is enabled either alone or together with legacy hierarchies
/proc/self/cgroup can contain entries of the form:

        0::/

This will cause lxcfs to fail the cgroup mounts because it parses out the empty
string "" and later on passes it to mount(). Let's skip such entries.

Signed-off-by: Christian Brauner <cbrauner@suse.de>