### PR TITLE
move lxcfs to minimal chroot

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -617,11 +617,11 @@ bool cgfs_chmod_file(const char *controller, const char *file, mode_t mode)
 
 	if (!tmpc)
 		return false;
-	/* BASEDIR / tmpc / file \0 */
-	len = strlen(BASEDIR) + strlen(tmpc) + strlen(file) + 3;
+	/* . + /file + \0 */
+	len = strlen(file) + 2;
 	pathname = alloca(len);
-	snprintf(pathname, len, "%s/%s/%s", BASEDIR, tmpc, file);
-	if (chmod(pathname, mode) < 0)
+	snprintf(pathname, len, "%s%s", *file == '/' ? "." : "", file);
+	if (fchmodat(cfd, pathname, mode, 0) < 0)
 		return false;
 	return true;
 }

--- a/bindings.c
+++ b/bindings.c
@@ -860,12 +860,14 @@ bool is_child_cgroup(const char *controller, const char *cgroup, const char *f)
 
 	if (!tmpc)
 		return false;
-	/* BASEDIR / tmpc / cgroup / f \0 */
-	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cgroup) + strlen(f) + 4;
+	/* . + /cgroup + / + f + \0 */
+	len = strlen(cgroup) + strlen(f) + 3;
 	fnam = alloca(len);
-	snprintf(fnam, len, "%s/%s/%s/%s", BASEDIR, tmpc, cgroup, f);
+	ret = snprintf(fnam, len, "%s%s/%s", *cgroup == '/' ? "." : "", cgroup, f);
+	if (ret < 0 || (size_t)ret >= len)
+		return false;
 
-	ret = stat(fnam, &sb);
+	ret = fstatat(cfd, fnam, &sb, 0);
 	if (ret < 0 || !S_ISDIR(sb.st_mode))
 		return false;
 	return true;

--- a/bindings.c
+++ b/bindings.c
@@ -426,7 +426,7 @@ static bool in_comma_list(const char *needle, const char *haystack)
 	const char *s = haystack, *e;
 	size_t nlen = strlen(needle);
 
-	while (*s && (e = index(s, ','))) {
+	while (*s && (e = strchr(s, ','))) {
 		if (nlen != e - s) {
 			s = e + 1;
 			continue;
@@ -895,7 +895,7 @@ struct cgfs_files *cgfs_get_key(const char *controller, const char *cgroup, cons
 	if (file && *file == '/')
 		file++;
 
-	if (file && index(file, '/'))
+	if (file && strchr(file, '/'))
 		return NULL;
 
 	/* Make sure we pass a relative path to *at() family of functions.
@@ -917,8 +917,8 @@ struct cgfs_files *cgfs_get_key(const char *controller, const char *cgroup, cons
 	} while (!newkey);
 	if (file)
 		newkey->name = must_copy_string(file);
-	else if (rindex(cgroup, '/'))
-		newkey->name = must_copy_string(rindex(cgroup, '/'));
+	else if (strrchr(cgroup, '/'))
+		newkey->name = must_copy_string(strrchr(cgroup, '/'));
 	else
 		newkey->name = must_copy_string(cgroup);
 	newkey->uid = sb.st_uid;
@@ -1280,7 +1280,7 @@ static char *get_next_cgroup_dir(const char *taskcg, const char *querycg)
 		return NULL;
 	}
 
-	if (strcmp(querycg, "/") == 0)
+	if ((strcmp(querycg, "/") == 0) || (strcmp(querycg, "./") == 0))
 		start =  strdup(taskcg + 1);
 	else
 		start = strdup(taskcg + strlen(querycg) + 1);

--- a/bindings.c
+++ b/bindings.c
@@ -350,12 +350,6 @@ static bool write_string(const char *fnam, const char *string)
 	return true;
 }
 
-/*
- * hierarchies, i.e. 'cpu,cpuacct'
- */
-char **hierarchies;
-int num_hierarchies;
-
 struct cgfs_files {
 	char *name;
 	uint32_t uid, gid;

--- a/bindings.c
+++ b/bindings.c
@@ -384,7 +384,7 @@ static void print_subsystems(void)
 {
 	int i;
 
-	fprintf(stderr, "hierarchies:");
+	fprintf(stderr, "hierarchies:\n");
 	for (i = 0; i < num_hierarchies; i++) {
 		if (hierarchies[i])
 			fprintf(stderr, " %d: %s\n", i, hierarchies[i]);
@@ -435,10 +435,10 @@ bool cgfs_set_value(const char *controller, const char *cgroup, const char *file
 
 	if (!tmpc)
 		return false;
-	/* basedir / tmpc / cgroup / file \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cgroup) + strlen(file) + 4;
+	/* BASEDIR / tmpc / cgroup / file \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cgroup) + strlen(file) + 4;
 	fnam = alloca(len);
-	snprintf(fnam, len, "%s/%s/%s/%s", basedir, tmpc, cgroup, file);
+	snprintf(fnam, len, "%s/%s/%s/%s", BASEDIR, tmpc, cgroup, file);
 
 	return write_string(fnam, value);
 }
@@ -486,10 +486,10 @@ int cgfs_create(const char *controller, const char *cg, uid_t uid, gid_t gid)
 
 	if (!tmpc)
 		return -EINVAL;
-	/* basedir / tmpc / cg \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cg) + 3;
+	/* BASEDIR / tmpc / cg \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cg) + 3;
 	dirnam = alloca(len);
-	snprintf(dirnam, len, "%s/%s/%s", basedir,tmpc, cg);
+	snprintf(dirnam, len, "%s/%s/%s", BASEDIR,tmpc, cg);
 
 	if (mkdir(dirnam, 0755) < 0)
 		return -errno;
@@ -576,10 +576,10 @@ bool cgfs_remove(const char *controller, const char *cg)
 
 	if (!tmpc)
 		return false;
-	/* basedir / tmpc / cg \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cg) + 3;
+	/* BASEDIR / tmpc / cg \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cg) + 3;
 	dirnam = alloca(len);
-	snprintf(dirnam, len, "%s/%s/%s", basedir,tmpc, cg);
+	snprintf(dirnam, len, "%s/%s/%s", BASEDIR,tmpc, cg);
 	return recursive_rmdir(dirnam);
 }
 
@@ -590,10 +590,10 @@ bool cgfs_chmod_file(const char *controller, const char *file, mode_t mode)
 
 	if (!tmpc)
 		return false;
-	/* basedir / tmpc / file \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(file) + 3;
+	/* BASEDIR / tmpc / file \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(file) + 3;
 	pathname = alloca(len);
-	snprintf(pathname, len, "%s/%s/%s", basedir, tmpc, file);
+	snprintf(pathname, len, "%s/%s/%s", BASEDIR, tmpc, file);
 	if (chmod(pathname, mode) < 0)
 		return false;
 	return true;
@@ -622,10 +622,10 @@ int cgfs_chown_file(const char *controller, const char *file, uid_t uid, gid_t g
 
 	if (!tmpc)
 		return -EINVAL;
-	/* basedir / tmpc / file \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(file) + 3;
+	/* BASEDIR / tmpc / file \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(file) + 3;
 	pathname = alloca(len);
-	snprintf(pathname, len, "%s/%s/%s", basedir, tmpc, file);
+	snprintf(pathname, len, "%s/%s/%s", BASEDIR, tmpc, file);
 	if (chown(pathname, uid, gid) < 0)
 		return -errno;
 
@@ -643,10 +643,10 @@ FILE *open_pids_file(const char *controller, const char *cgroup)
 
 	if (!tmpc)
 		return NULL;
-	/* basedir / tmpc / cgroup / "cgroup.procs" \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cgroup) + 4 + strlen("cgroup.procs");
+	/* BASEDIR / tmpc / cgroup / "cgroup.procs" \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cgroup) + 4 + strlen("cgroup.procs");
 	pathname = alloca(len);
-	snprintf(pathname, len, "%s/%s/%s/cgroup.procs", basedir, tmpc, cgroup);
+	snprintf(pathname, len, "%s/%s/%s/cgroup.procs", BASEDIR, tmpc, cgroup);
 	return fopen(pathname, "w");
 }
 
@@ -666,10 +666,10 @@ static bool cgfs_iterate_cgroup(const char *controller, const char *cgroup, bool
 	if (!tmpc)
 		return false;
 
-	/* basedir / tmpc / cgroup \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cgroup) + 3;
+	/* BASEDIR / tmpc / cgroup \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cgroup) + 3;
 	dirname = alloca(len);
-	snprintf(dirname, len, "%s/%s/%s", basedir, tmpc, cgroup);
+	snprintf(dirname, len, "%s/%s/%s", BASEDIR, tmpc, cgroup);
 
 	dir = opendir(dirname);
 	if (!dir)
@@ -761,10 +761,10 @@ bool cgfs_get_value(const char *controller, const char *cgroup, const char *file
 
 	if (!tmpc)
 		return false;
-	/* basedir / tmpc / cgroup / file \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cgroup) + strlen(file) + 4;
+	/* BASEDIR / tmpc / cgroup / file \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cgroup) + strlen(file) + 4;
 	fnam = alloca(len);
-	snprintf(fnam, len, "%s/%s/%s/%s", basedir, tmpc, cgroup, file);
+	snprintf(fnam, len, "%s/%s/%s/%s", BASEDIR, tmpc, cgroup, file);
 
 	*value = slurp_file(fnam);
 	return *value != NULL;
@@ -787,12 +787,12 @@ struct cgfs_files *cgfs_get_key(const char *controller, const char *cgroup, cons
 	if (file && index(file, '/'))
 		return NULL;
 
-	/* basedir / tmpc / cgroup / file \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cgroup) + 3;
+	/* BASEDIR / tmpc / cgroup / file \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cgroup) + 3;
 	if (file)
 		len += strlen(file) + 1;
 	fnam = alloca(len);
-	snprintf(fnam, len, "%s/%s/%s%s%s", basedir, tmpc, cgroup,
+	snprintf(fnam, len, "%s/%s/%s%s%s", BASEDIR, tmpc, cgroup,
 		file ? "/" : "", file ? file : "");
 
 	ret = stat(fnam, &sb);
@@ -838,10 +838,10 @@ bool is_child_cgroup(const char *controller, const char *cgroup, const char *f)
 
 	if (!tmpc)
 		return false;
-	/* basedir / tmpc / cgroup / f \0 */
-	len = strlen(basedir) + strlen(tmpc) + strlen(cgroup) + strlen(f) + 4;
+	/* BASEDIR / tmpc / cgroup / f \0 */
+	len = strlen(BASEDIR) + strlen(tmpc) + strlen(cgroup) + strlen(f) + 4;
 	fnam = alloca(len);
-	snprintf(fnam, len, "%s/%s/%s/%s", basedir, tmpc, cgroup, f);
+	snprintf(fnam, len, "%s/%s/%s/%s", BASEDIR, tmpc, cgroup, f);
 
 	ret = stat(fnam, &sb);
 	if (ret < 0 || !S_ISDIR(sb.st_mode))

--- a/bindings.c
+++ b/bindings.c
@@ -1323,10 +1323,18 @@ static bool caller_is_in_ancestor(pid_t pid, const char *contrl, const char *cg,
 	prune_init_slice(c2);
 
 	/*
-	 * callers pass in '/' for root cgroup, otherwise they pass
-	 * in a cgroup without leading '/'
+	 * callers pass in '/' or './' (openat()) for root cgroup, otherwise
+	 * they pass in a cgroup without leading '/'
+	 *
+	 * The original line here was:
+	 *	linecmp = *cg == '/' ? c2 : c2+1;
+	 * TODO: I'm not sure why you'd want to increment when *cg != '/'?
+	 *       Serge, do you know?
 	 */
-	linecmp = *cg == '/' ? c2 : c2+1;
+	if (*cg == '/' || !strncmp(cg, "./", 2))
+		linecmp = c2;
+	else
+		linecmp = c2 + 1;
 	if (strncmp(linecmp, cg, strlen(linecmp)) != 0) {
 		if (nextcg) {
 			*nextcg = get_next_cgroup_dir(linecmp, cg);

--- a/bindings.c
+++ b/bindings.c
@@ -1357,7 +1357,7 @@ static bool caller_may_see_dir(pid_t pid, const char *contrl, const char *cg)
 	char *c2, *task_cg;
 	size_t target_len, task_len;
 
-	if (strcmp(cg, "/") == 0)
+	if (strcmp(cg, "/") == 0 || strcmp(cg, "./") == 0)
 		return true;
 
 	c2 = get_pid_cgroup(pid, contrl);

--- a/bindings.c
+++ b/bindings.c
@@ -434,11 +434,15 @@ bool cgfs_set_value(const char *controller, const char *cgroup, const char *file
 {
 	int ret, fd, cfd;
 	size_t len;
-	char *fnam, *tmpc = find_mounted_controller(controller, &cfd);
+	char *fnam, *tmpc;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return false;
-	/* . + /cgroup + / + file + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /cgroup + / + file + \0
+	 */
 	len = strlen(cgroup) + strlen(file) + 3;
 	fnam = alloca(len);
 	ret = snprintf(fnam, len, "%s%s/%s", *cgroup == '/' ? "." : "", cgroup, file);
@@ -496,11 +500,15 @@ int cgfs_create(const char *controller, const char *cg, uid_t uid, gid_t gid)
 {
 	int cfd;
 	size_t len;
-	char *dirnam, *tmpc = find_mounted_controller(controller, &cfd);
+	char *dirnam, *tmpc;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return -EINVAL;
-	/* . + /cg + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /cg + \0
+	 */
 	len = strlen(cg) + 2;
 	dirnam = alloca(len);
 	snprintf(dirnam, len, "%s%s", *cg == '/' ? "." : "", cg);
@@ -593,11 +601,15 @@ bool cgfs_remove(const char *controller, const char *cg)
 {
 	int fd, cfd;
 	size_t len;
-	char *dirnam, *tmpc = find_mounted_controller(controller, &cfd);
+	char *dirnam, *tmpc;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return false;
-	/* . +  /cg + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . +  /cg + \0
+	 */
 	len = strlen(cg) + 2;
 	dirnam = alloca(len);
 	snprintf(dirnam, len, "%s%s", *cg == '/' ? "." : "", cg);
@@ -613,11 +625,15 @@ bool cgfs_chmod_file(const char *controller, const char *file, mode_t mode)
 {
 	int cfd;
 	size_t len;
-	char *pathname, *tmpc = find_mounted_controller(controller, &cfd);
+	char *pathname, *tmpc;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return false;
-	/* . + /file + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /file + \0
+	 */
 	len = strlen(file) + 2;
 	pathname = alloca(len);
 	snprintf(pathname, len, "%s%s", *file == '/' ? "." : "", file);
@@ -646,11 +662,15 @@ int cgfs_chown_file(const char *controller, const char *file, uid_t uid, gid_t g
 {
 	int cfd;
 	size_t len;
-	char *pathname, *tmpc = find_mounted_controller(controller, &cfd);
+	char *pathname, *tmpc;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return -EINVAL;
-	/* . + /file + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /file + \0
+	 */
 	len = strlen(file) + 2;
 	pathname = alloca(len);
 	snprintf(pathname, len, "%s%s", *file == '/' ? "." : "", file);
@@ -668,11 +688,15 @@ FILE *open_pids_file(const char *controller, const char *cgroup)
 {
 	int fd, cfd;
 	size_t len;
-	char *pathname, *tmpc = find_mounted_controller(controller, &cfd);
+	char *pathname, *tmpc;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return NULL;
-	/* . + /cgroup + / "cgroup.procs" + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /cgroup + / "cgroup.procs" + \0
+	 */
 	len = strlen(cgroup) + strlen("cgroup.procs") + 3;
 	pathname = alloca(len);
 	snprintf(pathname, len, "%s%s/cgroup.procs", *cgroup == '/' ? "." : "", cgroup);
@@ -701,7 +725,7 @@ static bool cgfs_iterate_cgroup(const char *controller, const char *cgroup, bool
 	if (!tmpc)
 		return false;
 
-	/* Make sure we pass a relative path to openat(). */
+	/* Make sure we pass a relative path to *at() family of functions. */
 	len = strlen(cgroup) + 1 /* . */ + 1 /* \0 */;
 	cg = alloca(len);
 	ret = snprintf(cg, len, "%s%s", *cgroup == '/' ? "." : "", cgroup);
@@ -797,11 +821,15 @@ bool cgfs_get_value(const char *controller, const char *cgroup, const char *file
 {
 	int ret, fd, cfd;
 	size_t len;
-	char *fnam, *tmpc = find_mounted_controller(controller, &cfd);
+	char *fnam, *tmpc;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return false;
-	/* . + /cgroup + / + file + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /cgroup + / + file + \0
+	 */
 	len = strlen(cgroup) + strlen(file) + 3;
 	fnam = alloca(len);
 	ret = snprintf(fnam, len, "%s%s/%s", *cgroup == '/' ? "." : "", cgroup, file);
@@ -820,10 +848,11 @@ struct cgfs_files *cgfs_get_key(const char *controller, const char *cgroup, cons
 {
 	int ret, cfd;
 	size_t len;
-	char *fnam, *tmpc = find_mounted_controller(controller, &cfd);
+	char *fnam, *tmpc;
 	struct stat sb;
 	struct cgfs_files *newkey;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return false;
 
@@ -833,7 +862,9 @@ struct cgfs_files *cgfs_get_key(const char *controller, const char *cgroup, cons
 	if (file && index(file, '/'))
 		return NULL;
 
-	/* . + /cgroup + / + file + \0 */
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /cgroup + / + file + \0
+	 */
 	len = strlen(cgroup) + 3;
 	if (file)
 		len += strlen(file) + 1;
@@ -880,13 +911,17 @@ bool is_child_cgroup(const char *controller, const char *cgroup, const char *f)
 {
 	int cfd;
 	size_t len;
-	char *fnam, *tmpc = find_mounted_controller(controller, &cfd);
+	char *fnam, *tmpc;
 	int ret;
 	struct stat sb;
 
+	tmpc = find_mounted_controller(controller, &cfd);
 	if (!tmpc)
 		return false;
-	/* . + /cgroup + / + f + \0 */
+
+	/* Make sure we pass a relative path to *at() family of functions.
+	 * . + /cgroup + / + f + \0
+	 */
 	len = strlen(cgroup) + strlen(f) + 3;
 	fnam = alloca(len);
 	ret = snprintf(fnam, len, "%s%s/%s", *cgroup == '/' ? "." : "", cgroup, f);
@@ -896,6 +931,7 @@ bool is_child_cgroup(const char *controller, const char *cgroup, const char *f)
 	ret = fstatat(cfd, fnam, &sb, 0);
 	if (ret < 0 || !S_ISDIR(sb.st_mode))
 		return false;
+
 	return true;
 }
 

--- a/bindings.h
+++ b/bindings.h
@@ -5,9 +5,17 @@
 /* Number of hierarchies mounted. */
 int num_hierarchies;
 
-/* Initialized via __constructor__ see bindings.c */
+/* Hierachies mounted {cpuset, blkio, ...}:
+ * Initialized via  static void __attribute__((constructor)) collect_subsystems(void)
+ * in bindings.c */
 char **hierarchies;
 
+/* Open file descriptors:
+ * @fd_hierarchies[i] refers to cgroup @hierarchies[i]. They are mounted in a
+ * private mount namespace. Initialized in main() in lxcfs.c.
+ * @fd_hierarchies[i] can be used to perform file operations on the files in the
+ * private namespace even when located in another namespace using the *at()
+ * family of functions {openat(), fchownat(), ...}. */
 int *fd_hierarchies;
 
 extern int cg_write(const char *path, const char *buf, size_t size, off_t offset,

--- a/bindings.h
+++ b/bindings.h
@@ -2,6 +2,14 @@
 #define BASEDIR RUNTIME_PATH "/lxcfs/controllers"
 #define ROOTDIR RUNTIME_PATH "/lxcfs/root"
 
+/* Number of hierarchies mounted. */
+int num_hierarchies;
+
+/* Initialized via __constructor__ see bindings.c */
+char **hierarchies;
+
+int *fd_hierarchies;
+
 extern int cg_write(const char *path, const char *buf, size_t size, off_t offset,
 	     struct fuse_file_info *fi);
 extern int cg_mkdir(const char *path, mode_t mode);

--- a/bindings.h
+++ b/bindings.h
@@ -2,22 +2,6 @@
 #define BASEDIR RUNTIME_PATH "/lxcfs/controllers"
 #define ROOTDIR RUNTIME_PATH "/lxcfs/root"
 
-/* Number of hierarchies mounted. */
-int num_hierarchies;
-
-/* Hierachies mounted {cpuset, blkio, ...}:
- * Initialized via  static void __attribute__((constructor)) collect_subsystems(void)
- * in bindings.c */
-char **hierarchies;
-
-/* Open file descriptors:
- * @fd_hierarchies[i] refers to cgroup @hierarchies[i]. They are mounted in a
- * private mount namespace. Initialized in main() in lxcfs.c.
- * @fd_hierarchies[i] can be used to perform file operations on the files in the
- * private namespace even when located in another namespace using the *at()
- * family of functions {openat(), fchownat(), ...}. */
-int *fd_hierarchies;
-
 extern int cg_write(const char *path, const char *buf, size_t size, off_t offset,
 	     struct fuse_file_info *fi);
 extern int cg_mkdir(const char *path, mode_t mode);

--- a/bindings.h
+++ b/bindings.h
@@ -1,5 +1,6 @@
 /* directory under which we mount the controllers - /run/lxcfs/controllers */
 #define BASEDIR RUNTIME_PATH "/lxcfs/controllers"
+#define ROOTDIR RUNTIME_PATH "/lxcfs/root"
 
 extern int cg_write(const char *path, const char *buf, size_t size, off_t offset,
 	     struct fuse_file_info *fi);

--- a/bindings.h
+++ b/bindings.h
@@ -1,5 +1,5 @@
 /* directory under which we mount the controllers - /run/lxcfs/controllers */
-#define basedir RUNTIME_PATH "/lxcfs/controllers"
+#define BASEDIR RUNTIME_PATH "/lxcfs/controllers"
 
 extern int cg_write(const char *path, const char *buf, size_t size, off_t offset,
 	     struct fuse_file_info *fi);

--- a/lxcfs.c
+++ b/lxcfs.c
@@ -789,8 +789,8 @@ static bool mkdir_p(const char *dir, mode_t mode)
 
 static bool umount_if_mounted(void)
 {
-	if (umount2(basedir, MNT_DETACH) < 0 && errno != EINVAL) {
-		fprintf(stderr, "failed to umount %s: %s\n", basedir,
+	if (umount2(BASEDIR, MNT_DETACH) < 0 && errno != EINVAL) {
+		fprintf(stderr, "failed to umount %s: %s\n", BASEDIR,
 			strerror(errno));
 		return false;
 	}
@@ -799,7 +799,7 @@ static bool umount_if_mounted(void)
 
 static bool setup_cgfs_dir(void)
 {
-	if (!mkdir_p(basedir, 0700)) {
+	if (!mkdir_p(BASEDIR, 0700)) {
 		fprintf(stderr, "Failed to create lxcfs cgdir\n");
 		return false;
 	}
@@ -807,7 +807,7 @@ static bool setup_cgfs_dir(void)
 		fprintf(stderr, "Failed to clean up old lxcfs cgdir\n");
 		return false;
 	}
-	if (mount("tmpfs", basedir, "tmpfs", 0, "size=100000,mode=700") < 0) {
+	if (mount("tmpfs", BASEDIR, "tmpfs", 0, "size=100000,mode=700") < 0) {
 		fprintf(stderr, "Failed to mount tmpfs for private controllers\n");
 		return false;
 	}
@@ -820,9 +820,9 @@ static bool do_mount_cgroup(char *controller)
 	size_t len;
 	int ret;
 
-	len = strlen(basedir) + strlen(controller) + 2;
+	len = strlen(BASEDIR) + strlen(controller) + 2;
 	target = alloca(len);
-	ret = snprintf(target, len, "%s/%s", basedir, controller);
+	ret = snprintf(target, len, "%s/%s", BASEDIR, controller);
 	if (ret < 0 || ret >= len)
 		return false;
 	if (mkdir(target, 0755) < 0 && errno != EEXIST)

--- a/lxcfs.c
+++ b/lxcfs.c
@@ -8,28 +8,28 @@
 
 #define FUSE_USE_VERSION 26
 
-#include <stdio.h>
 #include <dirent.h>
+#include <dlfcn.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <fuse.h>
-#include <unistd.h>
-#include <errno.h>
-#include <stdbool.h>
-#include <time.h>
-#include <string.h>
-#include <stdlib.h>
 #include <libgen.h>
-#include <sched.h>
 #include <pthread.h>
-#include <dlfcn.h>
-#include <linux/sched.h>
-#include <sys/socket.h>
-#include <sys/mount.h>
-#include <sys/epoll.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
 #include <wait.h>
+#include <linux/sched.h>
+#include <sys/epoll.h>
+#include <sys/mount.h>
+#include <sys/socket.h>
 
-#include "config.h" // for VERSION
 #include "bindings.h"
+#include "config.h" // for VERSION
 
 void *dlopen_handle;
 

--- a/lxcfs.c
+++ b/lxcfs.c
@@ -26,28 +26,11 @@
 #include <wait.h>
 #include <linux/sched.h>
 #include <sys/epoll.h>
-#include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/socket.h>
-#include <sys/syscall.h>
 
 #include "bindings.h"
 #include "config.h" // for VERSION
-
-/* Define pivot_root() if missing from the C library */
-#ifndef HAVE_PIVOT_ROOT
-static int pivot_root(const char * new_root, const char * put_old)
-{
-#ifdef __NR_pivot_root
-return syscall(__NR_pivot_root, new_root, put_old);
-#else
-errno = ENOSYS;
-return -1;
-#endif
-}
-#else
-extern int pivot_root(const char * new_root, const char * put_old);
-#endif
 
 void *dlopen_handle;
 
@@ -101,7 +84,7 @@ static void do_reload(void)
 
 	dlopen_handle = dlopen("/usr/lib/lxcfs/liblxcfs.so", RTLD_LAZY);
 	if (!dlopen_handle) {
-		fprintf(stderr, "Failed to open liblxcfs\n");
+		fprintf(stderr, "Failed to open liblxcfs: %s.\n", dlerror());
 		_exit(1);
 	}
 
@@ -130,27 +113,6 @@ static void down_users(void)
 static void reload_handler(int sig)
 {
 	need_reload = 1;
-}
-
-/*
- * Functions and types to ease the use of clone()/__clone2()
- */
-pid_t lxcfs_clone(int (*fn)(void *), void *arg, int flags)
-{
-	size_t stack_size = sysconf(_SC_PAGESIZE);
-	void *stack = alloca(stack_size);
-	pid_t ret;
-
-#ifdef __ia64__
-	ret = __clone2(do_clone, stack,
-		       stack_size, flags | SIGCHLD, &clone_arg);
-#else
-	ret = clone(fn, stack  + stack_size, flags | SIGCHLD, &arg);
-#endif
-	if (ret < 0)
-		fprintf(stderr, "failed to clone (%#x): %s", flags, strerror(errno));
-
-	return ret;
 }
 
 /* Functions to run the library methods */
@@ -802,213 +764,6 @@ bool swallow_option(int *argcp, char *argv[], char *opt, char **v)
 	return false;
 }
 
-static bool mkdir_p(const char *dir, mode_t mode)
-{
-	const char *tmp = dir;
-	const char *orig = dir;
-	char *makeme;
-
-	do {
-		dir = tmp + strspn(tmp, "/");
-		tmp = dir + strcspn(dir, "/");
-		makeme = strndup(orig, dir - orig);
-		if (!makeme)
-			return false;
-		if (mkdir(makeme, mode) && errno != EEXIST) {
-			fprintf(stderr, "failed to create directory '%s': %s",
-				makeme, strerror(errno));
-			free(makeme);
-			return false;
-		}
-		free(makeme);
-	} while(tmp != dir);
-
-	return true;
-}
-
-static bool umount_if_mounted(void)
-{
-	if (umount2(BASEDIR, MNT_DETACH) < 0 && errno != EINVAL) {
-		fprintf(stderr, "failed to umount %s: %s\n", BASEDIR,
-			strerror(errno));
-		return false;
-	}
-	return true;
-}
-
-static int pivot_enter(void)
-{
-	int ret = -1, oldroot = -1, newroot = -1;
-
-	oldroot = open("/", O_DIRECTORY | O_RDONLY);
-	if (oldroot < 0) {
-		fprintf(stderr, "%s: Failed to open old root for fchdir.\n", __func__);
-		return ret;
-	}
-
-	newroot = open(ROOTDIR, O_DIRECTORY | O_RDONLY);
-	if (newroot < 0) {
-		fprintf(stderr, "%s: Failed to open new root for fchdir.\n", __func__);
-		goto err;
-	}
-
-	/* change into new root fs */
-	if (fchdir(newroot) < 0) {
-		fprintf(stderr, "%s: Failed to change directory to new rootfs: %s.\n", __func__, ROOTDIR);
-		goto err;
-	}
-
-	/* pivot_root into our new root fs */
-	if (pivot_root(".", ".") < 0) {
-		fprintf(stderr, "%s: pivot_root() syscall failed: %s.\n", __func__, strerror(errno));
-		goto err;
-	}
-
-	/*
-	 * At this point the old-root is mounted on top of our new-root.
-	 * To unmounted it we must not be chdir'd into it, so escape back
-	 * to the old-root.
-	 */
-	if (fchdir(oldroot) < 0) {
-		fprintf(stderr, "%s: Failed to enter old root.\n", __func__);
-		goto err;
-	}
-	if (umount2(".", MNT_DETACH) < 0) {
-		fprintf(stderr, "%s: Failed to detach old root.\n", __func__);
-		goto err;
-	}
-
-	if (fchdir(newroot) < 0) {
-		fprintf(stderr, "%s: Failed to re-enter new root.\n", __func__);
-		goto err;
-	}
-
-	ret = 0;
-
-err:
-	if (oldroot > 0)
-		close(oldroot);
-	if (newroot > 0)
-		close(newroot);
-	return ret;
-}
-
-/* Prepare our new clean root. */
-static int pivot_prepare(void)
-{
-	if (mkdir(ROOTDIR, 0700) < 0 && errno != EEXIST) {
-		fprintf(stderr, "%s: Failed to create directory for new root.\n", __func__);
-		return -1;
-	}
-
-	if (mount("/", ROOTDIR, NULL, MS_BIND, 0) < 0) {
-		fprintf(stderr, "%s: Failed to bind-mount / for new root: %s.\n", __func__, strerror(errno));
-		return -1;
-	}
-
-	if (mount(RUNTIME_PATH, ROOTDIR RUNTIME_PATH, NULL, MS_BIND, 0) < 0) {
-		fprintf(stderr, "%s: Failed to bind-mount /run into new root: %s.\n", __func__, strerror(errno));
-		return -1;
-	}
-
-	if (mount(BASEDIR, ROOTDIR BASEDIR, NULL, MS_REC | MS_MOVE, 0) < 0) {
-		printf("%s: failed to move " BASEDIR " into new root: %s.\n", __func__, strerror(errno));
-		return -1;
-	}
-
-	return 0;
-}
-
-static bool pivot_new_root(void)
-{
-	/* Prepare new root. */
-	if (pivot_prepare() < 0)
-		return false;
-
-	/* Pivot into new root. */
-	if (pivot_enter() < 0)
-		return false;
-
-	return true;
-}
-
-static bool setup_cgfs_dir(void)
-{
-	if (!mkdir_p(BASEDIR, 0700)) {
-		fprintf(stderr, "Failed to create lxcfs cgdir\n");
-		return false;
-	}
-	if (!umount_if_mounted()) {
-		fprintf(stderr, "Failed to clean up old lxcfs cgdir\n");
-		return false;
-	}
-	if (mount("tmpfs", BASEDIR, "tmpfs", 0, "size=100000,mode=700") < 0) {
-		fprintf(stderr, "Failed to mount tmpfs for private controllers\n");
-		return false;
-	}
-	return true;
-}
-
-static bool do_mount_cgroups(void)
-{
-	char *target;
-	size_t clen, len;
-	int i, ret;
-
-	for (i = 0; i < num_hierarchies; i++) {
-		char *controller = hierarchies[i];
-		clen = strlen(controller);
-		len = strlen(BASEDIR) + clen + 2;
-		target = malloc(len);
-		if (!target)
-			return false;
-		ret = snprintf(target, len, "%s/%s", BASEDIR, controller);
-		if (ret < 0 || ret >= len) {
-			free(target);
-			return false;
-		}
-		if (mkdir(target, 0755) < 0 && errno != EEXIST) {
-			free(target);
-			return false;
-		}
-		if (mount(controller, target, "cgroup", 0, controller) < 0) {
-			fprintf(stderr, "Failed mounting cgroup %s\n", controller);
-			free(target);
-			return false;
-		}
-
-		fd_hierarchies[i] = open(target, O_DIRECTORY);
-		if (fd_hierarchies[i] < 0) {
-			free(target);
-			return false;
-		}
-		free(target);
-	}
-	return true;
-}
-
-static int cgfs_setup_controllers(void *data)
-{
-	if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, 0) < 0) {
-		fprintf(stderr, "%s: Failed to re-mount / private: %s.\n", __func__, strerror(errno));
-		return -1;
-	}
-
-	if (!setup_cgfs_dir()) {
-		return false;
-	}
-
-	if (!do_mount_cgroups()) {
-		fprintf(stderr, "Failed to set up cgroup mounts\n");
-		return false;
-	}
-
-	if (!pivot_new_root())
-		return false;
-
-	return true;
-}
-
 static int set_pidfile(char *pidfile)
 {
 	int fd;
@@ -1051,20 +806,12 @@ static int set_pidfile(char *pidfile)
 	return fd;
 }
 
-static void close_fd_hierarchies(void)
-{
-	int i;
-	for (i = 0; i < num_hierarchies; i++)
-		if (fd_hierarchies[i] > 0)
-			close(fd_hierarchies[i]);
-}
-
 int main(int argc, char *argv[])
 {
 	int ret = EXIT_FAILURE;
 	int pidfd = -1;
 	char *pidfile = NULL, *v = NULL;
-	size_t pidfile_len, mmap_len = 0;
+	size_t pidfile_len;
 	/*
 	 * what we pass to fuse_main is:
 	 * argv[0] -s -f -o allow_other,directio argv[1] NULL
@@ -1106,27 +853,6 @@ int main(int argc, char *argv[])
 	newargv[cnt++] = argv[1];
 	newargv[cnt++] = NULL;
 
-	/* Now use clone(CLONE_NEWNS | CLONE_FILES) to mount cgroup hierarchies
-	 * in a private mount namespace to hide them from other processes that
-	 * would otherwise get confused. As fuse needs to be able to perform
-	 * file operations on the cgroup hierarchies. Hence we share open file
-	 * descriptors opened in the private mount namespace referring to those
-	 * hierarchies between child and parent process. */
-	mmap_len = sizeof(int *) * num_hierarchies;
-	fd_hierarchies = mmap(NULL, mmap_len, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-	if (!fd_hierarchies)
-		goto out;
-
-	pid_t pid = lxcfs_clone(cgfs_setup_controllers, NULL, CLONE_NEWNS | CLONE_FILES);
-	if (pid < 0) {
-		fprintf(stderr, "%s: Error cloning new mount namespace: %s\n", __func__, strerror(errno));
-		goto out;
-	}
-	if (waitpid(pid, NULL, 0) < 0) {
-		fprintf(stderr, "%s: Error waiting on cloned child: %s\n", __func__, strerror(errno));
-		goto out;
-	}
-
 	if (!pidfile) {
 		pidfile_len = strlen(RUNTIME_PATH) + strlen("/lxcfs.pid") + 1;
 		pidfile = alloca(pidfile_len);
@@ -1145,8 +871,5 @@ out:
 		unlink(pidfile);
 	if (pidfd > 0)
 		close(pidfd);
-	close_fd_hierarchies();
-	if (fd_hierarchies)
-		munmap(fd_hierarchies, mmap_len);
 	exit(ret);
 }


### PR DESCRIPTION
lxcfs now creates a private mount namespace (actually rather a minimal chroot)
to hide its cgroup mounts under BASEDIR/ from other processes that would get
confused by it. However, the fuse mount usually placed under /var/lib/lxcfs (or
whatever the user gives us via argv[1]) needs to be visible in the initial
namespace. Hence, we place these mounts in different namespaces. ~~This requires
some coordination. fuse_mount() needs to be called in the initial namespace.
Afterwards we can unshare(CLONE_NEWNS), setup the cgroup mounts and create our
minimal chroot. On failure we need to switch back to the initial mount namespace
for fuse_umount() to succeed.
In addition, when we are asked to reload our dynamic library, we also need to
switch to the initial mount namespace.~~

Signed-off-by: Christian Brauner <cbrauner@suse.de>
