### PR TITLE
don't use argv[0] in usage output

### DIFF
--- a/lxcfs.c
+++ b/lxcfs.c
@@ -708,13 +708,13 @@ const struct fuse_operations lxcfs_ops = {
 	.fgetattr = NULL,
 };
 
-static void usage(const char *me)
+static void usage()
 {
 	fprintf(stderr, "Usage:\n");
 	fprintf(stderr, "\n");
-	fprintf(stderr, "%s [-p pidfile] mountpoint\n", me);
+	fprintf(stderr, "lxcfs [-p pidfile] mountpoint\n");
 	fprintf(stderr, "  Default pidfile is %s/lxcfs.pid\n", RUNTIME_PATH);
-	fprintf(stderr, "%s -h\n", me);
+	fprintf(stderr, "lxcfs -h\n");
 	exit(1);
 }
 
@@ -838,7 +838,7 @@ int main(int argc, char *argv[])
 		exit(EXIT_SUCCESS);
 	}
 	if (argc != 2 || is_help(argv[1]))
-		usage(argv[0]);
+		usage();
 
 	do_reload();
 	if (signal(SIGUSR1, reload_handler) == SIG_ERR) {


### PR DESCRIPTION
otherwise this generates "funny" manpages like

    /home/remote/egolov/Devel/lxcfs/.libs/lt-lxcfs [-p pidfile] mountpoint
    /home/remote/egolov/Devel/lxcfs/.libs/lt-lxcfs -h

or

    /build/lxcfs-8lNGve/lxcfs-2.0/.1/.libs/lt-lxcfs [-p pidfile] mountpoint
    /build/lxcfs-8lNGve/lxcfs-2.0/.1/.libs/lt-lxcfs -h

Signed-off-by: Evgeni Golov <evgeni@debian.org>