### PR TITLE
bindings: revert cgroup check and improve fs behavior

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -1926,11 +1926,8 @@ int cg_access(const char *path, int mode)
 	struct cgfs_files *k = NULL;
 	struct fuse_context *fc = fuse_get_context();
 
-	if (strcmp(path, "/cgroup") == 0) {
-		if ((mode & W_OK) == 0)
-			return -EACCES;
+	if (strcmp(path, "/cgroup") == 0)
 		return 0;
-	}
 
 	if (!fc)
 		return -EIO;


### PR DESCRIPTION
We do not need to check whether mode & W_OK is passed in. Even if the cgroup
root mount is writeable operations like cg_mkdir() et al. will fail with e.g.
EPERM. Basically all operations will fail on the cgroup root mount point because
the first operation they perform is pick_controller_from_path(). That is to say
they try to e.g. pick "blkio" from /var/lib/lxcfs/cgroup/blkio/some/cgroups an
similiar for all other controllers. If pick_controller_from_path() fails they
all return an appropriate errno. For example, cg_mkdir() does:

        controller = pick_controller_from_path(fc, path);
        if (!controller)
                return errno == ENOENT ? -EPERM : -errno;

This means, we do not need to return an errno already in cg_access when
mode & W_OK is passed in. This has the advantage that users are still able to
descend into /var/lib/lxcfs/cgroup via:

        cd /var/lib/lxcfs/cgroup

but are still blocked from doing any write operations.

Signed-off-by: Christian Brauner <cbrauner@suse.de>