### PR TITLE
configure.ac: create symbolic links to config/init/*/lxcfs* files in the build directory 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,30 +66,29 @@ endif
 
 tests: TEST_READ TEST_CPUSET TEST_SYSCALLS
 
-distclean:
-	rm -rf .deps/ \
-		INSTALL \
-		Makefile \
-		Makefile.in \
-		aclocal.m4 \
-		autom4te.cache/ \
-		compile \
-		config.guess \
-		config.h \
-		config.h.in \
-		config.log \
-		config.status \
-		config.sub \
-		configure \
-		depcomp \
-		install-sh \
-		libtool \
-		ltmain.sh \
-		lxcfs \
-		lxcfs.1 \
-		lxcfs.o \
-		m4/ \
-		missing \
-		stamp-h1 \
-		tests/test_syscalls \
-		*.lo *.la
+DISTCLEANFILES = INSTALL \
+	            Makefile.in \
+	            aclocal.m4 \
+	            compile \
+	            config.guess \
+	            config.h.in \
+	            config.sub \
+	            config/Makefile.in \
+	            config/init/Makefile.in \
+	            config/init/systemd/Makefile.in \
+	            config/init/sysvinit/Makefile.in \
+	            config/init/upstart/Makefile.in \
+	            configure \
+	            depcomp \
+	            install-sh \
+	            ltmain.sh \
+	            m4/libtool.m4 \
+	            m4/ltoptions.m4 \
+	            m4/ltsugar.m4 \
+	            m4/ltversion.m4 \
+	            m4/lt~obsolete.m4 \
+	            missing \
+	            share/Makefile.in \
+	            tests/Makefile.in \
+				lxcfs.1
+

--- a/config/init/systemd/Makefile.am
+++ b/config/init/systemd/Makefile.am
@@ -1,7 +1,7 @@
 EXTRA_DIST = lxcfs.service
 
 if INIT_SCRIPT_SYSTEMD
-SYSTEMD_UNIT_DIR = /lib/systemd/system
+SYSTEMD_UNIT_DIR = $(libdir)/systemd/system
 
 install-systemd: lxcfs.service
 	$(MKDIR_P) $(DESTDIR)$(SYSTEMD_UNIT_DIR)

--- a/config/init/systemd/Makefile.am
+++ b/config/init/systemd/Makefile.am
@@ -5,7 +5,7 @@ SYSTEMD_UNIT_DIR = /lib/systemd/system
 
 install-systemd: lxcfs.service
 	$(MKDIR_P) $(DESTDIR)$(SYSTEMD_UNIT_DIR)
-	$(INSTALL_DATA) lxcfs.service $(DESTDIR)$(SYSTEMD_UNIT_DIR)/
+	$(INSTALL_DATA) $(abs_srcdir)/lxcfs.service $(DESTDIR)$(SYSTEMD_UNIT_DIR)/
 
 uninstall-systemd:
 	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/lxcfs.service

--- a/config/init/sysvinit/Makefile.am
+++ b/config/init/sysvinit/Makefile.am
@@ -3,7 +3,7 @@ EXTRA_DIST = lxcfs
 if INIT_SCRIPT_SYSV
 install-sysvinit: lxcfs
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/rc.d/init.d
-	$(INSTALL_SCRIPT) lxcfs $(DESTDIR)$(sysconfdir)/rc.d/init.d/lxcfs
+	$(INSTALL_SCRIPT) $(abs_srcdir)/lxcfs $(DESTDIR)$(sysconfdir)/rc.d/init.d/lxcfs
 
 uninstall-sysvinit:
 	rm -f $(DESTDIR)$(sysconfdir)/rc.d/init.d/lxcfs

--- a/config/init/upstart/Makefile.am
+++ b/config/init/upstart/Makefile.am
@@ -3,7 +3,7 @@ EXTRA_DIST = lxcfs.conf
 if INIT_SCRIPT_UPSTART
 install-upstart: lxcfs.conf
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/init/
-	$(INSTALL_DATA) lxcfs.conf $(DESTDIR)$(sysconfdir)/init/
+	$(INSTALL_DATA) $(abs_srcdir)/lxcfs.conf $(DESTDIR)$(sysconfdir)/init/
 
 uninstall-upstart:
 	rm -f $(DESTDIR)$(sysconfdir)/init/lxcfs.conf

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,11 @@ AC_CONFIG_FILES([
 	share/lxc.reboot.hook
 	tests/Makefile ])
 
+AC_CONFIG_LINKS([
+	config/init/sysvinit/lxcfs:config/init/sysvinit/lxcfs
+	config/init/systemd/lxcfs.service:config/init/systemd/lxcfs.service
+	config/init/upstart/lxcfs.conf:config/init/upstart/lxcfs.conf ])
+
 LT_INIT
 AC_PROG_CC
 

--- a/configure.ac
+++ b/configure.ac
@@ -22,11 +22,6 @@ AC_CONFIG_FILES([
 	share/lxc.reboot.hook
 	tests/Makefile ])
 
-AC_CONFIG_LINKS([
-	config/init/sysvinit/lxcfs:config/init/sysvinit/lxcfs
-	config/init/systemd/lxcfs.service:config/init/systemd/lxcfs.service
-	config/init/upstart/lxcfs.conf:config/init/upstart/lxcfs.conf ])
-
 LT_INIT
 AC_PROG_CC
 


### PR DESCRIPTION
Building lxcfs in a directory that is different from the source directory would fail at the installation phase 
because make couldn't find files "config/init/_/lxcfs_" in the build folder. 

Signed-off-by: Liu Kui kllk2320@gmail.com
