### PR TITLE
Fix wrong scanning of memory.stat

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -2958,19 +2958,19 @@ static void parse_memstat(char *memstat, unsigned long *cached,
 
 	while (*memstat) {
 		if (startswith(memstat, "cache")) {
-			sscanf(memstat + 11, "%lu", cached);
+			sscanf(memstat + 5, "%lu", cached);
 			*cached /= 1024;
 		} else if (startswith(memstat, "active_anon")) {
 			sscanf(memstat + 11, "%lu", active_anon);
 			*active_anon /= 1024;
 		} else if (startswith(memstat, "inactive_anon")) {
-			sscanf(memstat + 11, "%lu", inactive_anon);
+			sscanf(memstat + 13, "%lu", inactive_anon);
 			*inactive_anon /= 1024;
 		} else if (startswith(memstat, "active_file")) {
 			sscanf(memstat + 11, "%lu", active_file);
 			*active_file /= 1024;
 		} else if (startswith(memstat, "inactive_file")) {
-			sscanf(memstat + 11, "%lu", inactive_file);
+			sscanf(memstat + 13, "%lu", inactive_file);
 			*inactive_file /= 1024;
 		} else if (startswith(memstat, "unevictable")) {
 			sscanf(memstat + 11, "%lu", unevictable);


### PR DESCRIPTION
/proc/meminfo displays wrong value.

```
# lxc-attach -n lxc02 -- mount | grep meminfo
lxcfs on /proc/meminfo type fuse.lxcfs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
# lxc-attach -n lxc02 -- grep ^cache /sys/fs/cgroup/memory/lxc/lxc02/memory.stat
cache 8593408
# lxc-attach -n lxc02 -- grep -i ^cache /proc/meminfo
Cached:                0 kB
```

Signed-off-by: KUWAZAWA Takuya albatross0@gmail.com
