### PR TITLE
bindings: allow getattr on O_WRONLY files

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -1673,7 +1673,13 @@ int cg_getattr(const char *path, struct stat *sb)
 			ret = -ENOENT;
 			goto out;
 		}
-		if (!fc_may_access(fc, controller, path1, path2, O_RDONLY)) {
+		/* We should only deny getting the attributes of a file if it
+		 * neither contains O_RDONLY permission nor O_WRONLY
+		 * permissions. Otherwise we ls -al will not show attributes on
+		 * O_WRONLY files. Such files are quite common under /proc or
+		 * /sys. */
+		if (!fc_may_access(fc, controller, path1, path2, O_RDONLY) &&
+		    !fc_may_access(fc, controller, path1, path2, O_WRONLY)) {
 			ret = -EACCES;
 			goto out;
 		}


### PR DESCRIPTION
We should only deny getting the attributes of a file if it neither contains
`O_RDONLY` permission nor `O_WRONLY` permissions. Otherwise `ls -al` will not show
attributes on `O_WRONLY` files. Such files are quite common under `/proc` or `/sys`.

BEFORE:
```
root@conventiont:~# ls -al /var/lib/lxcfs/cgroup/devices/
ls: cannot access '/var/lib/lxcfs/cgroup/devices/devices.allow': Permission denied
ls: cannot access '/var/lib/lxcfs/cgroup/devices/devices.deny': Permission denied
total 0
drwxr-xr-x 2 root root 0 Oct  7 01:00 .
drwxr-xr-x 2 root root 0 Oct  7 01:00 ..
-rw-r--r-- 1 root root 0 Oct  7 01:00 cgroup.clone_children
-rw-r--r-- 1 root root 0 Oct  7 01:00 cgroup.procs
-r--r--r-- 1 root root 0 Oct  7 01:00 cgroup.sane_behavior
?????????? ? ?    ?    ?            ? devices.allow
?????????? ? ?    ?    ?            ? devices.deny
-r--r--r-- 1 root root 0 Oct  7 01:00 devices.list
drwxr-xr-x 2 root root 0 Oct  7 01:00 init.scope
drwxr-xr-x 2 root root 0 Oct  7 01:00 lxc
-rw-r--r-- 1 root root 0 Oct  7 01:00 notify_on_release
-rw-r--r-- 1 root root 0 Oct  7 01:00 release_agent
drwxr-xr-x 2 root root 0 Oct  7 01:00 system.slice
-rw-r--r-- 1 root root 0 Oct  7 01:00 tasks
drwxr-xr-x 2 root root 0 Oct  7 01:00 user.slice
```

AFTER:
```
root@conventiont:~# ls -al /var/lib/lxcfs/cgroup/devices/
total 0
drwxr-xr-x 2 root root 0 Oct  7 01:01 .
drwxr-xr-x 2 root root 0 Oct  7 01:01 ..
-rw-r--r-- 1 root root 0 Oct  7 01:01 cgroup.clone_children
-rw-r--r-- 1 root root 0 Oct  7 01:01 cgroup.procs
-r--r--r-- 1 root root 0 Oct  7 01:01 cgroup.sane_behavior
--w------- 1 root root 0 Oct  7 01:01 devices.allow
--w------- 1 root root 0 Oct  7 01:01 devices.deny
-r--r--r-- 1 root root 0 Oct  7 01:01 devices.list
drwxr-xr-x 2 root root 0 Oct  7 01:01 init.scope
drwxr-xr-x 2 root root 0 Oct  7 01:01 lxc
-rw-r--r-- 1 root root 0 Oct  7 01:01 notify_on_release
-rw-r--r-- 1 root root 0 Oct  7 01:01 release_agent
drwxr-xr-x 2 root root 0 Oct  7 01:01 system.slice
-rw-r--r-- 1 root root 0 Oct  7 01:01 tasks
drwxr-xr-x 2 root root 0 Oct  7 01:01 user.slice
```

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

Closes #149.