### PR TITLE
bindings: remove noop check

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -1673,17 +1673,6 @@ int cg_getattr(const char *path, struct stat *sb)
 			ret = -ENOENT;
 			goto out;
 		}
-		/* We should only deny getting the attributes of a file if it
-		 * neither contains O_RDONLY permission nor O_WRONLY
-		 * permissions. Otherwise we ls -al will not show attributes on
-		 * O_WRONLY files. Such files are quite common under /proc or
-		 * /sys. */
-		if (!fc_may_access(fc, controller, path1, path2, O_RDONLY) &&
-		    !fc_may_access(fc, controller, path1, path2, O_WRONLY)) {
-			ret = -EACCES;
-			goto out;
-		}
-
 		ret = 0;
 	}
 


### PR DESCRIPTION
Unless the file was created with chmod 000 the current check for
!O_RDONLY && !O_WRONLY will always be successful, making the current check
basically a noop. And even in the case where a file has chmod 000 we still want
the user to see that it has no permissions. So let's remove the check entirely.
Whether a user sees a file will be determined by a prior check for O_RDONLY on
the directory anyway.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>