### PR TITLE
fix Active/Inactive /proc/meminfo

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -3192,11 +3192,11 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 		} else if (startswith(line, "SwapCached:")) {
 			snprintf(lbuf, 100, "SwapCached:     %8lu kB\n", 0UL);
 			printme = lbuf;
-		} else if (startswith(line, "Active")) {
+		} else if (startswith(line, "Active:")) {
 			snprintf(lbuf, 100, "Active:         %8lu kB\n",
 					active_anon + active_file);
 			printme = lbuf;
-		} else if (startswith(line, "Inactive")) {
+		} else if (startswith(line, "Inactive:")) {
 			snprintf(lbuf, 100, "Inactive:       %8lu kB\n",
 					inactive_anon + inactive_file);
 			printme = lbuf;


### PR DESCRIPTION
the missing : makes the other branches for lines starting with "Active" and "Inactive" unreachable, leading to /proc/meminfo content like this:

...
Active:            24484 kB
Inactive:           7468 kB
Active:            24484 kB
Inactive:           7468 kB
Active:            24484 kB
Inactive:           7468 kB
...

instead of:

...
Active:            16020 kB
Inactive:        8372040 kB
Active(anon):      14580 kB
Inactive(anon):    14868 kB
Active(file):       1440 kB
Inactive(file):  8357172 kB
...

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>