### PR TITLE
tests: Fix run on ppc64el

### DIFF
--- a/tests/test_cgroup
+++ b/tests/test_cgroup
@@ -42,12 +42,12 @@ for p in ${mempath} ${frzpath} ${cpupath}; do
 done
 
 # set values though lxcfs
-echo $((1024*1024)) > ${LXCFSDIR}/cgroup/memory/${initmemory}/${UUID}/memory.limit_in_bytes
+echo $((64*1024*1024)) > ${LXCFSDIR}/cgroup/memory/${initmemory}/${UUID}/memory.limit_in_bytes
 echo 0 > ${LXCFSDIR}/cgroup/cpuset/${initcpuset}/${UUID}/cpuset.cpus
 
 # and verify them through cgroupfs
 v=`cat $mempath/${UUID}/memory.limit_in_bytes`
-[ "$v" = "$((1024*1024))" ]
+[ "$v" = "$((64*1024*1024))" ]
 v=`cat ${cpupath}/${UUID}/cpuset.cpus`
 [ "$v" = "0" ]
 

--- a/tests/test_proc
+++ b/tests/test_proc
@@ -32,7 +32,7 @@ mkdir ${mempath}/lxcfs_test_proc
 echo 1 > ${cpupath}/lxcfs_test_proc/tasks
 echo 1 > ${mempath}/lxcfs_test_proc/tasks
 
-echo $((1024*1024)) > ${mempath}/lxcfs_test_proc/memory.limit_in_bytes
+echo $((64*1024*1024)) > ${mempath}/lxcfs_test_proc/memory.limit_in_bytes
 echo 0 > ${cpupath}/lxcfs_test_proc/cpuset.cpus
 
 # Test uptime
@@ -46,7 +46,7 @@ grep -q "^processor.*0$" ${LXCFSDIR}/proc/cpuinfo
 [ "$(grep "^cpu" ${LXCFSDIR}/proc/stat | wc -l)" = "2" ]
 
 # Test meminfo
-grep -q "^MemTotal.*1024 kB$" ${LXCFSDIR}/proc/meminfo
+grep -q "^MemTotal.*65536 kB$" ${LXCFSDIR}/proc/meminfo
 
 PASS=1
 echo PASS


### PR DESCRIPTION
Turns out a MB of memory isn't quite enough to run things like cat on
some architectures, so lets bump to a more comfortable 64MB.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>