### PR TITLE
Also check next variable for NULL on cg_rmdir

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -2908,7 +2908,7 @@ int cg_rmdir(const char *path)
 	if (initpid <= 0)
 		initpid = fc->pid;
 	if (!caller_is_in_ancestor(initpid, controller, cgroup, &next)) {
-		if (!last || strcmp(next, last) == 0)
+		if (!last || (next && (strcmp(next, last) == 0)))
 			ret = -EBUSY;
 		else
 			ret = -ENOENT;


### PR DESCRIPTION
lxcfs seems to crash in cg_rmdir while phpsessioncleanup is running in many containers simultaneously.

Here is a stack trace:
```
Detaching after fork from child process 17921.
Reading in symbols for ../sysdeps/x86_64/multiarch/../strcmp.S...done.

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fba74fc4700 (LWP 214112)]
__strcmp_ssse3 () at ../sysdeps/x86_64/multiarch/../strcmp.S:1358
1358    ../sysdeps/x86_64/multiarch/../strcmp.S: No such file or directory.
Reading in symbols for ../sysdeps/unix/sysv/linux/x86_64/clone.S...done.
#0  __strcmp_ssse3 () at ../sysdeps/x86_64/multiarch/../strcmp.S:1358
No locals.
#1  0x00007fba75099de3 in cg_rmdir () from /usr/lib/lxcfs/liblxcfs.so
No symbol table info available.
#2  0x000055952dda6c8e in ?? ()
No symbol table info available.
#3  0x00007fba75a9a404 in ?? () from /lib/x86_64-linux-gnu/libfuse.so.2
No symbol table info available.
#4  0x00007fba75aa422b in ?? () from /lib/x86_64-linux-gnu/libfuse.so.2
No symbol table info available.
#5  0x00007fba75aa0e49 in ?? () from /lib/x86_64-linux-gnu/libfuse.so.2
No symbol table info available.
#6  0x00007fba75675184 in start_thread (arg=0x7fba74fc4700) at pthread_create.c:312
```

I can only guess that the caller_is_in_ancestor returns false and sets next to NULL - then the strcmp crashes.

I hope the ret errno is correct for this case.