### PR TITLE
Add reload in service scripts

### DIFF
--- a/config/init/systemd/lxcfs.service
+++ b/config/init/systemd/lxcfs.service
@@ -10,6 +10,7 @@ KillMode=process
 Restart=on-failure
 ExecStopPost=-/bin/fusermount -u /var/lib/lxcfs
 Delegate=yes
+ExecReload=/bin/kill -USR1 $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/config/init/sysvinit/lxcfs
+++ b/config/init/sysvinit/lxcfs
@@ -80,6 +80,13 @@ case "$1" in
         fi
         status_of_proc -p ${PIDFILE} "${DAEMON}" lxcfs
     ;;
+    
+    reload)
+        if init_is_upstart; then
+            exit 1
+        fi
+        kill -USR1 $(cat /var/run/lxcfs.pid)
+    ;;
 
     restart|force-reload)
         if init_is_upstart; then


### PR DESCRIPTION
Add reload feature in sysV and systemd scripts.

Upstart doesn't have such an option since it assume that every service use the SIGHUP for configuration reload