### PR TITLE
(temporarily?) revert the virtualization of btime field in /proc/stat

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -3672,10 +3672,7 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 			continue;
 		if (sscanf(line, "cpu%9[^ ]", cpu_char) != 1) {
 			/* not a ^cpuN line containing a number N, just print it */
-			if (strncmp(line, "btime", 5) == 0)
-				l = snprintf(cache, cache_size, "btime %"PRIu64"\n", get_reaper_btime(fc->pid));
-			else
-				l = snprintf(cache, cache_size, "%s", line);
+			l = snprintf(cache, cache_size, "%s", line);
 			if (l < 0) {
 				perror("Error writing to cache");
 				rv = 0;


### PR DESCRIPTION
Closes #189

This seems to be responsible for corrupting STIME on processlist
inside containers.  Hopefully we can find a reasonable way to fix
both, but compared to unvirtualized btime field, bogus STIME field
is the greater evil here.

Signed-off-by: Serge Hallyn <serge@hallyn.com>