### PR TITLE
add cgroupfs-mount to Should-Start/Stop sysvinit LSB headers

### DIFF
--- a/config/init/sysvinit/lxcfs
+++ b/config/init/sysvinit/lxcfs
@@ -6,6 +6,8 @@
 # Provides:             lxcfs
 # Required-Start:       $remote_fs
 # Required-Stop:        $remote_fs
+# Should-Start:         cgroupfs-mount
+# Should-Stop:          cgroupfs-mount
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
 ### END INIT INFO


### PR DESCRIPTION
otherwise init might try to start lxcfs before cgroupfs was mounted,
which will result in an empty /var/lib/lxcfs/cgroup and weird issues.

Debian-Bug: https://bugs.debian.org/859219
Signed-off-by: Evgeni Golov <evgeni@debian.org>