### PR TITLE
modify default liblxcfs.so path, becasue the default prefix is /usr/l…

### DIFF
--- a/lxcfs.c
+++ b/lxcfs.c
@@ -86,7 +86,7 @@ static void do_reload(void)
 		goto good;
 	}
 
-	dlopen_handle = dlopen("/usr/lib/lxcfs/liblxcfs.so", RTLD_LAZY);
+	dlopen_handle = dlopen("/usr/local/lib/lxcfs/liblxcfs.so", RTLD_LAZY);
 	if (!dlopen_handle) {
 		lxcfs_error("Failed to open liblxcfs.so: %s.\n", dlerror());
 		_exit(1);


### PR DESCRIPTION
…ocal, and liblxcfs.so will be installed in /usr/local/lib/ by default.

![image](https://user-images.githubusercontent.com/4158830/27728180-d745ebc0-5db3-11e7-8114-c1554218bb34.png)

Signed-off-by: Daniel Kang <kangliang424@gmail.com>