### PR TITLE
Fix installation directory of liblxcfs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ liblxcfstest_la_LDFLAGS = $(AM_CFLAGS) -module -avoid-version -shared
 noinst_HEADERS = bindings.h macro.h
 
 sodir=$(libdir)
-lib_LTLIBRARIES = liblxcfs.la
+lxcfs_LTLIBRARIES = liblxcfs.la
 EXTRA_LTLIBRARIES = liblxcfstest.la
 
 lxcfs_SOURCES = lxcfs.c

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,7 @@ AM_CONDITIONAL([INIT_SCRIPT_UPSTART], [echo "$init_script" |grep -q "upstart"])
 AC_MSG_RESULT($init_script)
 
 
+AC_SUBST([lxcfsdir], "${libdir}/lxcfs")
 AC_ARG_WITH(
 	[pamdir],
 	[AS_HELP_STRING([--with-pamdir=PATH],[Specify the directory where PAM modules are stored,


### PR DESCRIPTION
This patch fixes the installation of liblxcfs to ${libdir}/lxcfs where do_reload in lxcfs.c actually looks for. Without this patch, liblxcfs gets installed in ${libdir} which conflicts with the location do_reload searches for.

Testing:
With patch make install shows following:
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/local/lib/lxcfs

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to '/etc/ld.so.conf'

Without patch, make install shows following:
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/local/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to '/etc/ld.so.conf'


 