### PR TITLE
Fix the installation directory for liblxcfs to ${libdir}/lxcfs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ liblxcfstest_la_LDFLAGS = $(AM_CFLAGS) -module -avoid-version -shared
 noinst_HEADERS = bindings.h macro.h
 
 sodir=$(libdir)
-lib_LTLIBRARIES = liblxcfs.la
+lxcfs_LTLIBRARIES = liblxcfs.la
 EXTRA_LTLIBRARIES = liblxcfstest.la
 
 lxcfs_SOURCES = lxcfs.c

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,7 @@ AM_CONDITIONAL([INIT_SCRIPT_UPSTART], [echo "$init_script" |grep -q "upstart"])
 AC_MSG_RESULT($init_script)
 
 
+AC_SUBST([lxcfsdir], "${libdir}/lxcfs")
 AC_ARG_WITH(
 	[pamdir],
 	[AS_HELP_STRING([--with-pamdir=PATH],[Specify the directory where PAM modules are stored,


### PR DESCRIPTION
This patch fixes the target installation directory for liblxcfs. do_reload function in lxcfs.c looks for the library in ${libdir}/lxcfs but the autotools installs it in ${libdir}

Testing:
With this patch, install gives following output:
```bash
/bin/mkdir -p '/usr/local/bin'
  /bin/bash ./libtool   --mode=install /usr/bin/install -c lxcfs '/usr/local/bin'
libtool: install: /usr/bin/install -c lxcfs /usr/local/bin/lxcfs
 /bin/mkdir -p '/usr/local/lib/lxcfs'
 /bin/bash ./libtool   --mode=install /usr/bin/install -c   liblxcfs.la '/usr/local/lib/lxcfs'
libtool: install: /usr/bin/install -c .libs/liblxcfs.so /usr/local/lib/lxcfs/liblxcfs.so
libtool: install: /usr/bin/install -c .libs/liblxcfs.lai /usr/local/lib/lxcfs/liblxcfs.la
libtool: finish: PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/sbin" ldconfig -n /usr/local/lib/lxcfs
```
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/local/lib/lxcfs

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to '/etc/ld.so.conf'

Without this patch,following output is seen:
```bash
/bin/mkdir -p '/usr/local/lib'
 /bin/bash ./libtool   --mode=install /usr/bin/install -c   liblxcfs.la '/usr/local/lib'
libtool: install: /usr/bin/install -c .libs/liblxcfs.so /usr/local/lib/liblxcfs.so
libtool: install: /usr/bin/install -c .libs/liblxcfs.lai /usr/local/lib/liblxcfs.la
libtool: finish: PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/sbin" ldconfig -n /usr/local/lib
```
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/local/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to '/etc/ld.so.conf'


Signed-off-by: Nagarathnam Muthusamy <nagarathnam.muthusamy@oracle.com>