### PR TITLE
loadavg: restart thread on library reload

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -97,6 +97,7 @@ struct file_info {
  * 1 means use loadavg, 0 means not use.
  */
 static int loadavg = 0;
+static volatile sig_atomic_t loadavg_stop = 0;
 static int calc_hash(char *name)
 {
 	unsigned int hash = 0;
@@ -247,7 +248,7 @@ static struct load_node *del_node(struct load_node *n, int locate)
 	return g;
 }
 
-void load_free(void)
+static void load_free(void)
 {
 	int i;
 	struct load_node *f, *p;
@@ -4500,6 +4501,9 @@ void *load_begin(void *arg)
 	clock_t time1, time2;
 
 	while (1) {
+		if (loadavg_stop == 1)
+			return NULL;
+
 		time1 = clock();
 		for (i = 0; i < LOAD_SIZE; i++) {
 			pthread_mutex_lock(&load_hash[i].lock);
@@ -4536,6 +4540,10 @@ out:					f = f->next;
 				}
 			}
 		}
+
+		if (loadavg_stop == 1)
+			return NULL;
+
 		time2 = clock();
 		usleep(FLUSH_TIME * 1000000 - (int)((time2 - time1) * 1000000 / CLOCKS_PER_SEC));
 	}
@@ -4647,6 +4655,26 @@ pthread_t load_daemon(int load_use)
 	/* use loadavg, here loadavg = 1*/
 	loadavg = load_use;
 	return pid;
+}
+
+/* Returns 0 on success. */
+int stop_load_daemon(pthread_t pid)
+{
+	int s;
+
+	/* Signal the thread to gracefully stop */
+	loadavg_stop = 1;
+
+	s = pthread_join(pid, NULL); /* Make sure sub thread has been canceled. */
+	if (s != 0) {
+		lxcfs_error("%s\n", "stop_load_daemon error: failed to join");
+		return -1;
+	}
+
+	load_free();
+	loadavg_stop = 0;
+
+	return 0;
 }
 
 static off_t get_procfile_size(const char *which)

--- a/bindings.h
+++ b/bindings.h
@@ -33,6 +33,6 @@ extern int proc_read(const char *path, char *buf, size_t size, off_t offset,
 		struct fuse_file_info *fi);
 extern int proc_access(const char *path, int mask);
 extern pthread_t load_daemon(int load_use);
-extern void load_free(void);
+extern int stop_load_daemon(pthread_t pid);
 
 #endif /* __LXCFS_BINDINGS_H */


### PR DESCRIPTION
Per-container loadavg tracking is not working after library reload using `SIGUSR1`. When reloading the library in `do_reload()`, the thread that is tracking per-container loadavgs is left running. As I understand it, it continues to operate on those static variables from the original library. loadavg is not set up using the new library and so `proc_read_loadavg()` starts to return the host's `/proc/loadavg`, as if it was disabled.

This patch stops the loadavg thread before closing the original library and restarts it when the new library is loaded.