### PR TITLE
meminfo: read shmem from memory cgroup

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -3434,6 +3434,12 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 		} else if (startswith(line, "Shmem:")) {
 			snprintf(lbuf, 100, "Shmem:          %8lu kB\n", shmem);
 			printme = lbuf;
+		} else if (startswith(line, "ShmemHugePages")) {
+			snprintf(lbuf, 100, "ShmemHugePages: %8lu kB\n", 0UL);
+			printme = lbuf;
+		} else if (startswith(line, "ShmemPmdMapped")) {
+			snprintf(lbuf, 100, "ShmemPmdMapped: %8lu kB\n", 0UL);
+			printme = lbuf;
 		} else
 			printme = line;
 

--- a/bindings.c
+++ b/bindings.c
@@ -3162,7 +3162,7 @@ static bool startswith(const char *line, const char *pref)
 static void parse_memstat(char *memstat, unsigned long *cached,
 		unsigned long *active_anon, unsigned long *inactive_anon,
 		unsigned long *active_file, unsigned long *inactive_file,
-		unsigned long *unevictable)
+		unsigned long *unevictable, unsigned long *shmem)
 {
 	char *eol;
 
@@ -3185,6 +3185,9 @@ static void parse_memstat(char *memstat, unsigned long *cached,
 		} else if (startswith(memstat, "total_unevictable")) {
 			sscanf(memstat + 17, "%lu", unevictable);
 			*unevictable /= 1024;
+		} else if (startswith(memstat, "total_shmem")) {
+			sscanf(memstat + 11, "%lu", shmem);
+			*shmem /= 1024;
 		}
 		eol = strchr(memstat, '\n');
 		if (!eol)
@@ -3301,7 +3304,7 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 		*memswlimit_str = NULL, *memswusage_str = NULL;
 	unsigned long memlimit = 0, memusage = 0, memswlimit = 0, memswusage = 0,
 		cached = 0, hosttotal = 0, active_anon = 0, inactive_anon = 0,
-		active_file = 0, inactive_file = 0, unevictable = 0,
+		active_file = 0, inactive_file = 0, unevictable = 0, shmem = 0,
 		hostswtotal = 0;
 	char *line = NULL;
 	size_t linelen = 0, total_len = 0, rv = 0;
@@ -3352,7 +3355,7 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 
 	parse_memstat(memstat_str, &cached, &active_anon,
 			&inactive_anon, &active_file, &inactive_file,
-			&unevictable);
+			&unevictable, &shmem);
 
 	f = fopen("/proc/meminfo", "r");
 	if (!f)
@@ -3427,6 +3430,9 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 			printme = lbuf;
 		} else if (startswith(line, "SUnreclaim")) {
 			snprintf(lbuf, 100, "SUnreclaim:     %8lu kB\n", 0UL);
+			printme = lbuf;
+		} else if (startswith(line, "Shmem:")) {
+			snprintf(lbuf, 100, "Shmem:          %8lu kB\n", shmem);
 			printme = lbuf;
 		} else
 			printme = line;


### PR DESCRIPTION
In `/proc/meminfo`, `Shmem` is passed as-is from the host while other values aren't. This causes `htop` to show incorrect memory usage, as described in #222. This patch makes it so that:

- `Shmem` is read from `memory.stat`. If it's not found, it is set to `0`.
- `ShmemHugePages` and `ShmemPmdPages` are always set to `0`, as I haven't found a cgroup counterpart. These values aren't related to the problem with `htop`.