### PR TITLE
tests: include missing sys/sysmacros.h header

### DIFF
--- a/tests/test_syscalls.c
+++ b/tests/test_syscalls.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <linux/un.h>


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>