### PR TITLE
bindings: prevent NULL pointer dereference

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -2136,7 +2136,7 @@ int cg_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset
 		goto out;
 	}
 
-	for (i = 0; list[i]; i++) {
+	for (i = 0; list && list[i]; i++) {
 		if (filler(buf, list[i]->name, NULL, 0) != 0) {
 			ret = -EIO;
 			goto out;


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/ubuntu/+source/lxcfs/+bug/1807628
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>