### PR TITLE
Adds mutex to do_release_file_info 

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -2169,11 +2169,16 @@ out:
 	return ret;
 }
 
+static pthread_mutex_t do_release_file_info_lock = PTHREAD_MUTEX_INITIALIZER;
+
 static void do_release_file_info(struct fuse_file_info *fi)
 {
+	lock_mutex(&do_release_file_info_lock);
+
 	struct file_info *f = (struct file_info *)fi->fh;
 
 	if (!f)
+		unlock_mutex(&do_release_file_info_lock);
 		return;
 
 	fi->fh = 0;
@@ -2188,6 +2193,8 @@ static void do_release_file_info(struct fuse_file_info *fi)
 	f->buf = NULL;
 	free(f);
 	f = NULL;
+
+	unlock_mutex(&do_release_file_info_lock);
 }
 
 int cg_releasedir(const char *path, struct fuse_file_info *fi)


### PR DESCRIPTION
Adds mutex to do_release_file_info to avoid lxcfs crash when stopping multiple containers concurrently.

Fixes https://github.com/lxc/lxcfs/issues/252