### PR TITLE
hooks: skip mounting lxcfs cgroup tree on centos 7 hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ m4/
 missing
 stamp-h1
 lxcfs.1
+lxcfs.spec
 share/00-lxcfs.conf
 share/lxc.mount.hook
 share/lxc.reboot.hook

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ bin_PROGRAMS = lxcfs
 
 EXTRA_DIST = \
 	lxcfs.man.add
+	lxcfs.spec
 
 if HAVE_HELP2MAN
 man_MANS = lxcfs.1

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_GNU_SOURCE
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
 	Makefile
+	lxcfs.spec
 	config/Makefile
 	config/init/Makefile
 	config/init/systemd/Makefile

--- a/lxcfs.spec.in
+++ b/lxcfs.spec.in
@@ -1,0 +1,77 @@
+# Set with_systemd on distros that use it, so we can install the service
+# file, otherwise the sysvinit script will be installed
+%if 0%{?fedora} >= 14 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1210
+%global with_systemd 1
+%define init_script systemd
+#
+# BuildRequires systemd-units on fedora and rhel
+%if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
+BuildRequires: systemd-units
+%endif
+#
+# BuildRequires systemd on openSUSE and SUSE
+%if 0%{?suse_version} >= 1210
+BuildRequires: systemd
+%endif
+%else
+%global with_systemd 0
+%define init_script sysvinit
+%endif
+
+Summary: Linux Containers File System
+Name: @PACKAGE@
+Version: @PACKAGE_VERSION@
+Release: 1%{?dist}
+URL: https://linuxcontainers.org/lxcfs/downloads/
+Source0: %{name}-%{version}.tar.gz
+License: Apache 2.0
+Group: System Environment/Libraries
+BuildRoot: %{_tmppath}/%{name}-root
+
+BuildRequires: gcc
+BuildRequires: libtool
+BuildRequires: docbook2X
+BuildRequires: doxygen
+BuildRequires: fuse-devel
+Requires: fuse-libs
+
+%description
+LXCFS is a simple userspace filesystem designed to work around some current limitations of the Linux kernel.
+
+%prep
+%setup -q
+
+%build
+%configure \
+	--with-init-script=%{init_script}
+%{make_build}
+
+#Modify mount hook command if running on RHEL 7 to skip cgroup mounts for stability reasons.
+%if 0%{?rhel} == 7
+sed -i 's/\/lxc.mount.hook/\/lxc.mount.hook --skip-cgroup-mounts/g' share/00-lxcfs.conf
+%endif
+
+%install
+[ %{buildroot} != "/" ] && rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}/%{_sharedstatedir}/%{name}
+
+%clean
+[ %{buildroot} != "/" ] && rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%dir %{_sharedstatedir}/%{name}
+%if %{with_systemd}
+/lib/systemd/system/%{name}.service
+%endif
+%{_bindir}/%{name}
+%config(noreplace) %{_datarootdir}/lxc/config/common.conf.d/00-%{name}.conf
+%{_datarootdir}/%{name}/lxc.mount.hook
+%{_datarootdir}/%{name}/lxc.reboot.hook
+%{_libdir}/%{name}/liblxcfs.la
+%{_libdir}/%{name}/liblxcfs.so
+
+%changelog
+* Wed Jan 30 2019 Tom Parrott <tomp@tomp.uk> - 3.1.0
+- Initial RPM release.

--- a/share/lxc.mount.hook.in
+++ b/share/lxc.mount.hook.in
@@ -1,5 +1,16 @@
 #!/bin/sh -e
 
+# Parse command flags
+while [ ! $# -eq 0 ]
+do
+	case "$1" in
+		--skip-cgroup-mounts )
+			SKIP_CGROUP_MOUNTS=1
+			;;
+	esac
+	shift
+done
+
 # We're dealing with mount entries, so expand any symlink
 LXC_ROOTFS_MOUNT=$(readlink -f ${LXC_ROOTFS_MOUNT})
 
@@ -26,6 +37,11 @@ if touch ${LXC_ROOTFS_MOUNT}/sys/fs/cgroup/lxcfs; then
     rm ${LXC_ROOTFS_MOUNT}/sys/fs/cgroup/lxcfs
 else
     exit 0
+fi
+
+# Skip mounting cgroup tree if requested.
+if [ "${SKIP_CGROUP_MOUNTS}" == "1" ]; then
+        exit 0
 fi
 
 # /sys/fs/cgroup files


### PR DESCRIPTION
hooks: Modifies lxc.mount.hook to skip mounting lxcfs cgroup tree when running CentOS 7 on the host.

This is due to instabilities when running lxcfs on CentOS 7 hosts.

/proc mounts do not cause any problems, so those are not skipped.

systemd containers still start OK with cgroup tree not mounted into lxcfs on CentOS 7 hosts.

Signed-off-by: tomponline <tomp@tomp.uk>

CC @Blub @brauner 