### PR TITLE
option to disable swap in meminfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,20 @@ send `SIGUSR1` to the pid of the running `LXCFS` process. This can be as simple
 as doing:
 
     kill -s USR1 $(pidof lxcfs)
+
+## Using with Docker
+
+```
+docker run -it -m 256m --memory-swap 256m \
+      -v /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw \
+      -v /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw \
+      -v /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw \
+      -v /var/lib/lxcfs/proc/stat:/proc/stat:rw \
+      -v /var/lib/lxcfs/proc/swaps:/proc/swaps:rw \
+      -v /var/lib/lxcfs/proc/uptime:/proc/uptime:rw \
+      ubuntu:18.04 /bin/bash
+ ```
+
+ In a system with swap enabled, the parameter "-u" can be used to set all values in "meminfo" that refer to the swap to 0.
+
+ sudo lxcfs -u /var/lib/lxcfs

--- a/bindings.h
+++ b/bindings.h
@@ -7,6 +7,10 @@
 #define BASEDIR RUNTIME_PATH "/lxcfs/controllers"
 #define ROOTDIR RUNTIME_PATH "/lxcfs/root"
 
+struct lxcfs_opts {
+	bool swap_off;
+};
+
 extern int cg_write(const char *path, const char *buf, size_t size, off_t offset,
 	     struct fuse_file_info *fi);
 extern int cg_mkdir(const char *path, mode_t mode);


### PR DESCRIPTION
Signed-off-by: Dieter Maier <dma@web.de>

It concerns the combination of a system with activated swap and docker. When I use lxcfs to limit the memory resources of a container, I always have swap.. Which I don't want.

docker run -it -m 256m --memory-swap 256m \
      -v /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw \
      -v /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw \
      -v /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw \
      -v /var/lib/lxcfs/proc/stat:/proc/stat:rw \
      -v /var/lib/lxcfs/proc/swaps:/proc/swaps:rw \
      -v /var/lib/lxcfs/proc/uptime:/proc/uptime:rw \
      ubuntu:18.04 /bin/bash

That, too, is not satisfactory:
docker run -it -m 256m \
      -v /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw \
      ....

I can force with the parameter "-u" that the swap values in the "meminfo" are always 0.

To use this parameter I use "fuse_get_context()->private_data".

It is a very special use case, but I wanted to at least suggest it.

I haven't programmed a C for a long time, so please take a critical look at it.

It works very well with Ubuntu. Unfortunately not with Alpine yet. I tested it with "free".

I developed the customization to use several mongodb on one docker host, which unfortunately have swap enabled. This works very well.