### PR TITLE
mount hook: mount /sys/devices/system/cpu/online

### DIFF
--- a/share/lxc.mount.hook.in
+++ b/share/lxc.mount.hook.in
@@ -22,6 +22,13 @@ if [ -d @LXCFSTARGETDIR@/proc/ ]; then
     done
 fi
 
+# /sys/devices/system/cpu
+if [ -d @LXCFSTARGETDIR@/sys/devices/system/cpu ] ; then
+    for entry in @LXCFSTARGETDIR@/sys/devices/system/cpu/*; do
+        [ -e "${LXC_ROOTFS_MOUNT}/sys/devices/system/cpu/$(basename $entry)" ] || continue
+        mount -n --bind $entry ${LXC_ROOTFS_MOUNT}/sys/devices/system/cpu/$(basename $entry)
+    done
+fi
 
 # Allow nesting lxcfs
 if [ -d ${LXC_ROOTFS_MOUNT}@LXCFSTARGETDIR@/ ]; then


### PR DESCRIPTION
Mount `/sys/devices/system/cpu/online` introduced by #278.