### PR TITLE
bindings: ensure that opts is non NULL

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -3504,22 +3504,22 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 		} else if (startswith(line, "MemAvailable:")) {
 			snprintf(lbuf, 100, "MemAvailable:   %8lu kB\n", memlimit - memusage + cached);
 			printme = lbuf;
-		} else if (startswith(line, "SwapTotal:") && memswlimit > 0 && opts->swap_off == false) {
+		} else if (startswith(line, "SwapTotal:") && memswlimit > 0 && opts && opts->swap_off == false) {
 			sscanf(line+sizeof("SwapTotal:")-1, "%lu", &hostswtotal);
 			if (hostswtotal < memswlimit)
 				memswlimit = hostswtotal;
 			snprintf(lbuf, 100, "SwapTotal:      %8lu kB\n", memswlimit);
 			printme = lbuf;
-		} else if (startswith(line, "SwapTotal:") && opts->swap_off == true) {
+		} else if (startswith(line, "SwapTotal:") && opts && opts->swap_off == true) {
 			snprintf(lbuf, 100, "SwapTotal:      %8lu kB\n", 0UL);
 			printme = lbuf;
-		} else if (startswith(line, "SwapFree:") && memswlimit > 0 && memswusage > 0 && opts->swap_off == false) {
+		} else if (startswith(line, "SwapFree:") && memswlimit > 0 && memswusage > 0 && opts && opts->swap_off == false) {
 			unsigned long swaptotal = memswlimit,
 					swapusage = memswusage - memusage,
 					swapfree = swapusage < swaptotal ? swaptotal - swapusage : 0;
 			snprintf(lbuf, 100, "SwapFree:       %8lu kB\n", swapfree);
 			printme = lbuf;
-		} else if (startswith(line, "SwapFree:") && opts->swap_off == true) {
+		} else if (startswith(line, "SwapFree:") && opts && opts->swap_off == true) {
 			snprintf(lbuf, 100, "SwapFree:       %8lu kB\n", 0UL);
 			printme = lbuf;
 		} else if (startswith(line, "Slab:")) {


### PR DESCRIPTION
When the shared library is reloaded but the lxcfs binary itself will
likely not be replaced and even if will still be in-memory, i.e. the
fuse loop will not be restarted.
The code here introduced a new struct lxcfs_opts which is allocated and
gets stashed in the private_data member of the fuse file when the lxcfs
binary is first called. Now, in a scenario where the shared library is
reloaded the lxcfs binary itself won't be re-run. So now we have a
shared library that assumes there's always a valid struct lxcfs_opts
stashed in the private_data member. But there isnt'. This very likely
causes the segfaults we have seen.

Fix it by verifying a struct has been stashed.

Fixes: 7e60aa1b1540 ("option to disable swap in meminfo")
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>