### PR TITLE
fix container run pid host mode /proc/stat error log

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -4884,14 +4884,14 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 	if (initpid <= 0)
 		initpid = fc->pid;
 
-    /*
-     * when container run with host pid namespace initpid == 1, cgroup will "/"
-     * we should return host os's /proc contents.
-     * in some case cpuacct_usage.all in "/" will larger then /proc/stat
-     */
-    if (initpid == 1) {
-        return read_file("/proc/stat", buf, size, d);
-    }
+	/*
+	 * when container run with host pid namespace initpid == 1, cgroup will "/"
+	 * we should return host os's /proc contents.
+	 * in some case cpuacct_usage.all in "/" will larger then /proc/stat
+	 */
+	if (initpid == 1) {
+	    return read_file("/proc/stat", buf, size, d);
+	}
 
 	cg = get_pid_cgroup(initpid, "cpuset");
 	lxcfs_v("cg: %s\n", cg);

--- a/bindings.c
+++ b/bindings.c
@@ -4883,6 +4883,16 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 	lxcfs_v("initpid: %d\n", initpid);
 	if (initpid <= 0)
 		initpid = fc->pid;
+
+    /*
+     * when container run with host pid namespace initpid == 1, cgroup will "/"
+     * we should return host os's /proc contents.
+     * in some case cpuacct_usage.all in "/" will larger then /proc/stat
+     */
+    if (initpid == 1) {
+        return read_file("/proc/stat", buf, size, d);
+    }
+
 	cg = get_pid_cgroup(initpid, "cpuset");
 	lxcfs_v("cg: %s\n", cg);
 	if (!cg)


### PR DESCRIPTION
This commit fix container run host pid namespace, the initpid will return 1.
then in same case lxcfs will get a lot of error, like this:
```
Aug  5 14:54:11 n10-019-024 lxcfs[3131]: bindings.c: 4503: cpuview_proc_stat: cpu23 from / has unexpected cpu time: 3954948 in /proc/stat, 4062974 in cpuacct.usage_all; unable to determine idle time
```
In some scenarios, the cgroup count is not accurate, which will cause the "/" counter to be greater than the system /proc/stat

so if initpid==1  we need return host os's /proc/stat. Instead of getting the data in the cgroup.
