### PR TITLE
macro: fix lxcfs_{error,debug,v} build error when __VA_ARGS__ is empty

### DIFF
--- a/macro.h
+++ b/macro.h
@@ -4,19 +4,19 @@
 #define lxcfs_debug_stream(stream, format, ...)                                \
 	do {                                                                   \
 		fprintf(stream, "%s: %d: %s: " format, __FILE__, __LINE__,     \
-			__func__, __VA_ARGS__);                                \
+			__func__, ##__VA_ARGS__);                                \
 	} while (false)
 
-#define lxcfs_error(format, ...) lxcfs_debug_stream(stderr, format, __VA_ARGS__)
+#define lxcfs_error(format, ...) lxcfs_debug_stream(stderr, format, ##__VA_ARGS__)
 
 #ifdef DEBUG
-#define lxcfs_debug(format, ...) lxcfs_error(format, __VA_ARGS__)
+#define lxcfs_debug(format, ...) lxcfs_error(format, ##__VA_ARGS__)
 #else
 #define lxcfs_debug(format, ...)
 #endif /* DEBUG */
 
 #ifdef VERBOSE
-#define lxcfs_v(format, ...) lxcfs_error(format, __VA_ARGS__);
+#define lxcfs_v(format, ...) lxcfs_error(format, ##__VA_ARGS__);
 #else
 #define lxcfs_v(format, ...)
 #endif /* VERBOSE */


### PR DESCRIPTION
Originally, the compiler complained:
  macro.h:7:25: error: expected expression before ')' token
      __func__, __VA_ARGS__);

The reason is that GCC wouldn't abandon `,` when `__VA_ARGS__` is empty.
For emaple:
```
  #define eprintf(format, ...) fprintf (stderr, format, __VA_ARGS__)
  eprintf("success!\n", );
       → fprintf(stderr, "success!\n", );
```

According to GCC doc, it's okay when adding `##` before `__VA_ARGS__`:
```
  #define eprintf(format, ...) fprintf (stderr, format, ##__VA_ARGS__)
  eprintf ("success!\n")
       → fprintf(stderr, "success!\n");
```