### PR TITLE
Fix proc_diskstats_read function

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -5356,11 +5356,17 @@ static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 
 	if (!cgfs_get_value("blkio", cg,
 						"blkio.throttle.io_serviced_recursive",
-						&io_serviced_str))
+						&io_serviced_str)
+		&& !cgfs_get_value("blkio", cg,
+						   "blkio.throttle.io_serviced",
+						   &io_serviced_str))
 		goto err;
 	if (!cgfs_get_value("blkio", cg,
 						"blkio.throttle.io_service_bytes_recursive",
-						&io_service_bytes_str))
+						&io_service_bytes_str)
+		&& !cgfs_get_value("blkio", cg,
+						   "blkio.throttle.io_service_bytes",
+						   &io_service_bytes_str))
 		goto err;
 
 	if (sscanf(io_serviced_str, "%d:%d", &major, &minor) != 2)

--- a/bindings.c
+++ b/bindings.c
@@ -3322,13 +3322,14 @@ static void parse_memstat(char *memstat, unsigned long *cached,
 	}
 }
 
-static void get_blkio_io_value(char *str, unsigned major, unsigned minor, char *iotype, unsigned long *v)
+static void get_blkio_io_value(char *str, int major, int minor,
+							   char *iotype, unsigned long *v)
 {
 	char *eol;
 	char key[32];
 
 	memset(key, 0, 32);
-	snprintf(key, 32, "%u:%u %s", major, minor, iotype);
+	snprintf(key, 32, "%d:%d %s", major, minor, iotype);
 
 	size_t len = strlen(key);
 	*v = 0;
@@ -5189,7 +5190,7 @@ static int proc_uptime_read(char *buf, size_t size, off_t offset,
 static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 		struct fuse_file_info *fi)
 {
-	char dev_name[72];
+	char dev_name[DISK_NAME_LEN];
 	struct fuse_context *fc = fuse_get_context();
 	struct file_info *d = (struct file_info *)fi->fh;
 	char *cg;
@@ -5205,7 +5206,7 @@ static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 	size_t cache_size = d->buflen;
 	char *line = NULL;
 	size_t linelen = 0, total_len = 0, rv = 0;
-	unsigned int major = 0, minor = 0;
+	int major = 0, minor = 0;
 	int i = 0;
 	FILE *f = NULL;
 
@@ -5278,9 +5279,12 @@ static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 
 		memset(lbuf, 0, 256);
 		if (read || write || read_merged || write_merged || read_sectors || write_sectors || read_ticks || write_ticks)
-			snprintf(lbuf, 256, "%u       %u %s %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu\n",
-				major, minor, dev_name, read, read_merged, read_sectors, read_ticks,
-				write, write_merged, write_sectors, write_ticks, ios_pgr, tot_ticks, rq_ticks);
+			snprintf(lbuf, 256, "%4d %7d %s %lu %lu %lu "
+					 "%lu %lu %lu %lu %lu %lu %lu %lu\n",
+					 major, minor, dev_name,
+					 read, read_merged, read_sectors, read_ticks,
+					 write, write_merged, write_sectors, write_ticks,
+					 ios_pgr, tot_ticks, rq_ticks);
 		else
 			continue;
 

--- a/bindings.h
+++ b/bindings.h
@@ -14,6 +14,9 @@
 /* Reserve buffer size to account for file size changes. */
 #define BUF_RESERVE_SIZE 512
 
+/* Maximun length of device name */
+#define DISK_NAME_LEN 32
+
 enum lxcfs_virt_t {
 	LXC_TYPE_CGDIR,
 	LXC_TYPE_CGFILE,


### PR DESCRIPTION
`# cat /proc/diskstats` sometime is none in container although using lxcfs. The reason is that incorrect way of getting printed information.

We could get block device information include device name, physical sector size, scheduler name from sysfs (`/sys/dev/block/<major:minor>/{uevent, queue/hw_sector_size, queue/scheduler}` by `major:minor`. No need to traverse `/proc/diskstats` to decide which disk information should be printed.

There are many scheduler in current linux kernel, for example: cfq, bfq, none, mq-deadline. cgroup block controller file `blkio.[a-z_]+` is only for cfq, and bfq is `blkio.bfq.[a-z_]+`. More general, throttle works at generic block layer suitable for any scheduler. So We could get `io_service` and `io_service_bytes` from throttle instead of specific scheduler.

Further, `blkio.*_recursive` show the same information as their non-recursive counterparts but include stats from all the descendant cgroups according to [linux doc](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt), and there is cgroup namespace. We collect data from 'blkio.*_recursive' for more accuracy.