### PR TITLE
fix /sys/devices/system/cpu/online in cpuset not correct bug

### DIFF
--- a/bindings.h
+++ b/bindings.h
@@ -82,5 +82,6 @@ extern char *get_cpuset(const char *cg);
 extern bool use_cpuview(const char *cg);
 extern int max_cpu_count(const char *cg);
 extern void do_release_file_info(struct fuse_file_info *fi);
+extern int cpu_number_in_cpuset(const char *cpuset);
 
 #endif /* __LXCFS_BINDINGS_H */

--- a/cpuset.c
+++ b/cpuset.c
@@ -43,3 +43,22 @@ bool cpu_in_cpuset(int cpu, const char *cpuset)
 	return false;
 }
 
+/*
+ * get cpu number in cpuset
+ */
+int cpu_number_in_cpuset(const char *cpuset)
+{
+	const char *c;
+	int cpu_number = 0;
+
+	for (c = cpuset; c; c = cpuset_nexttok(c)) {
+		int a, b, ret;
+
+		ret = cpuset_getrange(c, &a, &b);
+		if (ret == 1)
+			cpu_number++;
+		else if (ret == 2)
+			cpu_number +=  a > b ? a - b + 1 : b - a + 1;
+	}
+	return cpu_number;
+}

--- a/sysfs_fuse.c
+++ b/sysfs_fuse.c
@@ -46,6 +46,7 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 	bool use_view;
 
 	int max_cpus = 0;
+	int max_cpus_in_cpuset = 0;
 	pid_t initpid;
 	ssize_t total_len = 0;
 
@@ -76,6 +77,11 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 
 	if (use_view)
 		max_cpus = max_cpu_count(cg);
+
+	max_cpus_in_cpuset = cpu_number_in_cpuset(cpuset);
+	// use min value in cpu quota and cpuset
+	if (max_cpus_in_cpuset > 0)
+		max_cpus = max_cpus_in_cpuset > max_cpus ? max_cpus : max_cpus_in_cpuset;
 
 	if (max_cpus == 0)
 		return read_file("/sys/devices/system/cpu/online", buf, size, d);


### PR DESCRIPTION
When the container runs in cpuset and cpu quota, for example, cpu quota is limited to 8 cores, cpuset is limited to 1-3, 4-5, then there will be problems. The core number obtained by /proc/cpuinfo is 4 cores, and /sys /devices/system/cpu/online gets 8 cores.
The reason is that /sys/devices/system/cpu/online does not take into account the situation of cpuset. So submit this patch.

Test case:
`docker run -it -d  --cpuset-cpus="1-2,3-4" \
--cpu-period=100000 \
--cpu-quota=800000 \
--memory 2048m \
-v /root/tce/lxcfs/run/lxcfs/sys/devices/system/cpu/online:/sys/devices/system/cpu/online \
-v /root/tce/lxcfs/run/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw \
debian:latest bash
`




Signed-off-by: Hongbo Yin <yinhongbo@bytedance.com>