### PR TITLE
fix the problem of counting the number of CPUs when using cpuset and …

### DIFF
--- a/sysfs_fuse.c
+++ b/sysfs_fuse.c
@@ -46,7 +46,6 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 	bool use_view;
 
 	int max_cpus = 0;
-	int max_cpus_in_cpuset = 0;
 	pid_t initpid;
 	ssize_t total_len = 0;
 
@@ -77,11 +76,6 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 
 	if (use_view)
 		max_cpus = max_cpu_count(cg);
-
-	max_cpus_in_cpuset = cpu_number_in_cpuset(cpuset);
-	// use min value in cpu quota and cpuset
-	if (max_cpus_in_cpuset > 0)
-		max_cpus = max_cpus_in_cpuset > max_cpus ? max_cpus : max_cpus_in_cpuset;
 
 	if (max_cpus == 0)
 		return read_file("/sys/devices/system/cpu/online", buf, size, d);


### PR DESCRIPTION
This PR mainly fixes the problem of counting the number of CPUs when using cpuset and cpuset or using cpuset alone.
When using only cpuset

```
Docker run -it --rm \
--cpuset-cpus="0-4,6" \
--memory 2048m \
-v /var/run/lxcfs/sys/devices/system/cpu/online:/sys/devices/system/cpu/online \
-v /var/run/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw \
Ningx bash
```
Or when Cpuset and cpu quota are used at the same time, but the number of CPUs that cpuset can use is less than cpu quota.
```
Docker run -it --rm \
--cpu-period=100000 \
--cpu-quota=800000 \
--cpuset-cpus="0-4,6" \
--memory 2048m \
-v /var/run/lxcfs/sys/devices/system/cpu/online:/sys/devices/system/cpu/online \
-v /var/run/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw \
Ningx bash
```
Getting the number of CPUs in the container will be unsatisfactory.

Therefore, cpuset is introduced as the basis for the quantity judgment when calculating the maximum available CPU number.

This PR can also solve these ISSUE（such as [331](https://github.com/lxc/lxcfs/issues/301)） problems.

Signed-off-by: Hongbo Yin <yinhongbo@bytedance.com>