### PR TITLE
bindings: rework {con,de}structor

### DIFF
--- a/macro.h
+++ b/macro.h
@@ -75,4 +75,10 @@
 	     (__iterator = __it);                                               \
 	     __iterator = __it = strtok_r(NULL, __separators, &__p))
 
+#define log_exit(format, ...)                           \
+	({                                              \
+		fprintf(stderr, format, ##__VA_ARGS__); \
+		exit(EXIT_FAILURE);                     \
+	})
+
 #endif /* __LXCFS_MACRO_H */


### PR DESCRIPTION
- Improve naming for {con,de}structor.
- Fail when we can't setup cgroups.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>