### PR TITLE
tree-wide: switch default visibility to hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ that `LXCFS` uses will not need to be restarted. If it were then all containers
 using `LXCFS` would need to be restarted since they would otherwise be left
 with broken fuse mounts.
 
+To force a reload of the shared library at the next possible instance simply
+send `SIGUSR1` to the pid of the running `LXCFS` process. This can be as simple
+as doing:
+
+    kill -s USR1 $(pidof lxcfs)
+
 ### musl
 
 To achieve smooth upgrades through shared library reloads `LXCFS` also relies
@@ -46,8 +52,8 @@ on the fact that when `dlclose(3)` drops the last reference to the shared
 library destructors are run and when `dlopen(3)` is called constructors are
 run. While this is true for `glibc` it is not true for `musl` (See the section
 [Unloading libraries](https://wiki.musl-libc.org/functional-differences-from-glibc.html).).
-So users of `LXCFS` on `musl` are advised to restart `LXCFS` completely and
-- by extension - all containers.
+So users of `LXCFS` on `musl` are advised to restart `LXCFS` completely and all
+containers making use of it.
 
 ## Building
 Build lxcfs as follows:
@@ -81,18 +87,6 @@ lxc.autodev = 1
 lxc.kmsg = 0
 lxc.include = /usr/share/lxc/config/common.conf.d/00-lxcfs.conf
 ```
-
-## Upgrading LXCFS without breaking running containers
-LXCFS is implemented using a simple shared library without any external
-dependencies other than `FUSE`. It is completely reloadable without having to
-umount it. This ensures that container can be kept running even when the shared
-library is upgraded.
-
-To force a reload of the shared library at the next possible instance simply
-send `SIGUSR1` to the pid of the running `LXCFS` process. This can be as simple
-as doing:
-
-    kill -s USR1 $(pidof lxcfs)
 
 ## Using with Docker
 

--- a/cgroup_fuse.h
+++ b/cgroup_fuse.h
@@ -23,21 +23,18 @@
 #include "config.h"
 #include "macro.h"
 
-extern int cg_getattr(const char *path, struct stat *sb);
-extern int cg_mkdir(const char *path, mode_t mode);
-extern int cg_rmdir(const char *path);
-extern int cg_chmod(const char *path, mode_t mode);
-extern int cg_chown(const char *path, uid_t uid, gid_t gid);
-extern int cg_open(const char *path, struct fuse_file_info *fi);
-extern int cg_read(const char *path, char *buf, size_t size, off_t offset,
-		   struct fuse_file_info *fi);
-extern int cg_opendir(const char *path, struct fuse_file_info *fi);
-extern int cg_release(const char *path, struct fuse_file_info *fi);
-extern int cg_releasedir(const char *path, struct fuse_file_info *fi);
-extern int cg_write(const char *path, const char *buf, size_t size,
-		    off_t offset, struct fuse_file_info *fi);
-extern int cg_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-		      off_t offset, struct fuse_file_info *fi);
-extern int cg_access(const char *path, int mode);
+__visible extern int cg_getattr(const char *path, struct stat *sb);
+__visible extern int cg_mkdir(const char *path, mode_t mode);
+__visible extern int cg_rmdir(const char *path);
+__visible extern int cg_chmod(const char *path, mode_t mode);
+__visible extern int cg_chown(const char *path, uid_t uid, gid_t gid);
+__visible extern int cg_open(const char *path, struct fuse_file_info *fi);
+__visible extern int cg_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
+__visible extern int cg_opendir(const char *path, struct fuse_file_info *fi);
+__visible extern int cg_release(const char *path, struct fuse_file_info *fi);
+__visible extern int cg_releasedir(const char *path, struct fuse_file_info *fi);
+__visible extern int cg_write(const char *path, const char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
+__visible extern int cg_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+__visible extern int cg_access(const char *path, int mode);
 
 #endif /* __LXCFS_CGROUP_FUSE_H */

--- a/configure.ac
+++ b/configure.ac
@@ -227,6 +227,7 @@ AX_CHECK_COMPILE_FLAG([-Wnested-externs], [CFLAGS="$CFLAGS -Wnested-externs"],,[
 AX_CHECK_COMPILE_FLAG([-fasynchronous-unwind-tables], [CFLAGS="$CFLAGS -fasynchronous-unwind-tables"],,[-Werror])
 AX_CHECK_COMPILE_FLAG([-pipe], [CFLAGS="$CFLAGS -pipe"],,[-Werror])
 AX_CHECK_COMPILE_FLAG([-fexceptions], [CFLAGS="$CFLAGS -fexceptions"],,[-Werror])
+CFLAGS="$CFLAGS -fvisibility=hidden"
 
 AX_CHECK_LINK_FLAG([-z relro], [LDFLAGS="$LDFLAGS -z relro"],,[])
 AX_CHECK_LINK_FLAG([-z now], [LDFLAGS="$LDFLAGS -z now"],,[])

--- a/macro.h
+++ b/macro.h
@@ -106,4 +106,6 @@
 #define PTR_TO_UINT64(p) ((uint64_t)((intptr_t)(p)))
 #define INTTYPE_TO_PTR(u) ((void *)((intptr_t)(u)))
 
+#define __visible __attribute__((visibility("default")))
+
 #endif /* __LXCFS_MACRO_H */

--- a/proc_fuse.h
+++ b/proc_fuse.h
@@ -23,13 +23,11 @@
 #include "config.h"
 #include "macro.h"
 
-extern int proc_getattr(const char *path, struct stat *sb);
-extern int proc_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-			off_t offset, struct fuse_file_info *fi);
-extern int proc_open(const char *path, struct fuse_file_info *fi);
-extern int proc_access(const char *path, int mask);
-extern int proc_read(const char *path, char *buf, size_t size, off_t offset,
-		     struct fuse_file_info *fi);
-extern int proc_release(const char *path, struct fuse_file_info *fi);
+__visible extern int proc_getattr(const char *path, struct stat *sb);
+__visible extern int proc_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+__visible extern int proc_open(const char *path, struct fuse_file_info *fi);
+__visible extern int proc_access(const char *path, int mask);
+__visible extern int proc_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
+__visible extern int proc_release(const char *path, struct fuse_file_info *fi);
 
 #endif /* __LXCFS_PROC_FUSE_H */

--- a/sysfs_fuse.h
+++ b/sysfs_fuse.h
@@ -23,14 +23,12 @@
 #include "config.h"
 #include "macro.h"
 
-extern int sys_getattr(const char *path, struct stat *sb);
-extern int sys_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset,
-		struct fuse_file_info *fi);
-extern int sys_release(const char *path, struct fuse_file_info *fi);
-extern int sys_releasedir(const char *path, struct fuse_file_info *fi);
-extern int sys_open(const char *path, struct fuse_file_info *fi);
-extern int sys_read(const char *path, char *buf, size_t size, off_t offset,
-		struct fuse_file_info *fi);
-extern int sys_access(const char *path, int mask);
+__visible extern int sys_getattr(const char *path, struct stat *sb);
+__visible extern int sys_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+__visible extern int sys_release(const char *path, struct fuse_file_info *fi);
+__visible extern int sys_releasedir(const char *path, struct fuse_file_info *fi);
+__visible extern int sys_open(const char *path, struct fuse_file_info *fi);
+__visible extern int sys_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
+__visible extern int sys_access(const char *path, int mask);
 
 #endif /* __LXCFS_SYSFS_FUSE_H */


### PR DESCRIPTION
There's no need for anyone to call dlsym() on anything else than what we
explicitly support.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>