### PR TITLE
Unified cgroup fixups

### DIFF
--- a/src/cgroups/cgfsng.c
+++ b/src/cgroups/cgfsng.c
@@ -768,7 +768,7 @@ static bool cgfsng_can_use_cpuview(struct cgroup_ops *ops)
 	struct hierarchy *cpu, *cpuacct;
 
 	if (pure_unified_layout(ops))
-		return false;
+		return true;
 
 	cpu = ops->get_hierarchy(ops, "cpu");
 	if (!cpu || is_unified_hierarchy(cpu))


### PR DESCRIPTION
Implementation is debatable and minimal, but this was required to have at least `/proc/stat`, `/proc/cpuinfo`, `/proc/meminfo`, and `/sys/devices/system/cpu/online` behave under a unified layout.