### PR TITLE
configure: add -Wvla and -std=gnu11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,8 +248,8 @@ AX_CHECK_COMPILE_FLAG([-Wnested-externs], [CFLAGS="$CFLAGS -Wnested-externs"],,[
 AX_CHECK_COMPILE_FLAG([-fasynchronous-unwind-tables], [CFLAGS="$CFLAGS -fasynchronous-unwind-tables"],,[-Werror])
 AX_CHECK_COMPILE_FLAG([-pipe], [CFLAGS="$CFLAGS -pipe"],,[-Werror])
 AX_CHECK_COMPILE_FLAG([-fexceptions], [CFLAGS="$CFLAGS -fexceptions"],,[-Werror])
-CFLAGS="$CFLAGS -fvisibility=hidden"
 
+CFLAGS="$CFLAGS -fvisibility=hidden -Wvla -std=gnu11"
 AX_CHECK_LINK_FLAG([-z relro], [LDFLAGS="$LDFLAGS -z relro"],,[])
 AX_CHECK_LINK_FLAG([-z now], [LDFLAGS="$LDFLAGS -z now"],,[])
 

--- a/src/proc_cpuview.c
+++ b/src/proc_cpuview.c
@@ -433,7 +433,7 @@ static bool read_cpu_cfs_param(const char *cg, const char *param, int64_t *value
 	if (!cgroup_ops->get(cgroup_ops, "cpu", cg, file, &str))
 		return false;
 
-	if (sscanf(str, first ? "%"PRId64 : "%*"PRId64" %"PRId64, value) != 1)
+	if (sscanf(str, first ? "%" PRId64 : "%*" PRId64 " %" PRId64, value) != 1)
 		return false;
 
 	return true;


### PR DESCRIPTION
Both are standard in LXC for a long time now. And gcc-4.8 which is the
minimal compiler version we require (same as the Linux kernel) deals
with this.

Closes #362.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>