### PR TITLE
lxcfs: allow users to switch between virtualization and non-virtualization mode

### DIFF
--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -1030,8 +1030,7 @@ static bool cgroup_parse_memory_stat(const char *cgroup, struct memory_stat *mst
 static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 			     struct fuse_file_info *fi)
 {
-	__do_free char *cgroup = NULL, *line = NULL,
-		       *memusage_str = NULL, *memstat_str = NULL,
+	__do_free char *cgroup = NULL, *line = NULL, *memusage_str = NULL,
 		       *memswlimit_str = NULL, *memswusage_str = NULL;
 	__do_free void *fopen_cache = NULL;
 	__do_fclose FILE *f = NULL;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,6 +8,7 @@ EXTRA_DIST = \
 	test-read.c \
 	test_read_proc.sh \
 	test_reload.sh \
+	test_sigusr2.sh \
 	test_syscalls.c
 
 TEST_READ: test-read.c

--- a/tests/test_sigusr2.sh
+++ b/tests/test_sigusr2.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1+
+
+set -eu
+[ -n "${DEBUG:-}" ] && set -x
+
+PASS=0
+
+cleanup() {
+    [ "$PASS" = "1" ] || (echo FAIL && exit 1)
+}
+
+trap cleanup EXIT HUP INT TERM
+
+LXCFSDIR=${LXCFSDIR:-/var/lib/lxcfs}
+
+if ! mountpoint -q ${LXCFSDIR}; then
+    echo "lxcfs isn't mounted on ${LXCFSDIR}"
+    exit 1
+fi
+
+[ ! -d /sys/fs/cgroup/cpuset ] && exit 0
+
+# Test cpuinfo
+[ "$(grep "^processor" ${LXCFSDIR}/proc/cpuinfo | wc -l)" = "$(grep "^processor" /proc/cpuinfo | wc -l)" ]
+
+PASS=1


### PR DESCRIPTION
When LXCFS has a bug and provides wrong or inconsistent values user
often want to turn off virtualization until we have figured out a fix
and rollout an upgrade to reload the shared library. Allow them to
toggle between virtualization mode and non-virtualization mode by
sending SIGUSR2 to lxcfs:

 Kernel supports pidfds
 api_extensions:
 - cgroups
 - sys_cpu_online
 - proc_cpuinfo
 - proc_diskstats
 - proc_loadavg
 - proc_meminfo
 - proc_stat
 - proc_swaps
 - proc_uptime
 - shared_pidns
 - cpuview_daemon
 - loadavg_daemon
 - pidfds
 Switched into non-virtualization mode
 Switched into virtualization mode
 Switched into non-virtualization mode
 Switched into virtualization mode
 Switched into non-virtualization mode

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>