### PR TITLE
tree-wide: add and use syscall_numbers.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ liblxcfs_la_SOURCES = api_extensions.h \
 		      proc_cpuview.c proc_cpuview.h \
 		      proc_fuse.c proc_fuse.h \
 		      proc_loadavg.c proc_loadavg.h \
+		      syscall_numbers.h \
 		      sysfs_fuse.c sysfs_fuse.h \
 		      utils.c utils.h
 liblxcfs_la_CFLAGS = $(AM_CFLAGS)
@@ -48,6 +49,7 @@ liblxcfstest_la_SOURCES = api_extensions.h \
 			  proc_cpuview.c proc_cpuview.h \
 			  proc_fuse.c proc_fuse.h \
 			  proc_loadavg.c proc_loadavg.h \
+			  syscall_numbers.h \
 			  sysfs_fuse.c sysfs_fuse.h \
 			  utils.c utils.h
 liblxcfstest_la_CFLAGS = $(AM_CFLAGS) -DRELOADTEST
@@ -75,6 +77,7 @@ noinst_HEADERS = api_extensions.h \
 		 proc_cpuview.h \
 		 proc_fuse.h \
 		 proc_loadavg.h \
+		 syscall_numbers.h \
 		 sysfs_fuse.h \
 		 utils.h
 

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -46,6 +46,7 @@
 #include "config.h"
 #include "memory_utils.h"
 #include "proc_cpuview.h"
+#include "syscall_numbers.h"
 #include "utils.h"
 
 static bool can_use_pidfd;
@@ -61,12 +62,7 @@ bool liblxcfs_functional(void)
 #ifndef HAVE_PIVOT_ROOT
 static int pivot_root(const char *new_root, const char *put_old)
 {
-#ifdef __NR_pivot_root
 	return syscall(__NR_pivot_root, new_root, put_old);
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
 }
 #else
 extern int pivot_root(const char *new_root, const char *put_old);

--- a/src/syscall_numbers.h
+++ b/src/syscall_numbers.h
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+#ifndef __LXCFS_SYSCALL_NUMBERS_H
+#define __LXCFS_SYSCALL_NUMBERS_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <asm/unistd.h>
+#include <errno.h>
+#include <sched.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef __NR_pivot_root
+	#if defined __i386__
+		#define __NR_pivot_root 217
+	#elif defined __x86_64__
+		#define __NR_pivot_root	155
+	#elif defined __arm__
+		#define __NR_pivot_root 218
+	#elif defined __aarch64__
+		#define __NR_pivot_root 218
+	#elif defined __s390__
+		#define __NR_pivot_root 217
+	#elif defined __powerpc__
+		#define __NR_pivot_root 203
+	#elif defined __sparc__
+		#define __NR_pivot_root 146
+	#elif defined __ia64__
+		#define __NR_pivot_root 183
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pivot_root 4216
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pivot_root 6151
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pivot_root 5151
+		#endif
+	#else
+		#define -1
+		#warning "__NR_pivot_root not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_bpf
+	#if defined __i386__
+		#define __NR_bpf 357
+	#elif defined __x86_64__
+		#define __NR_bpf 321
+	#elif defined __arm__
+		#define __NR_bpf 386
+	#elif defined __aarch64__
+		#define __NR_bpf 386
+	#elif defined __s390__
+		#define __NR_bpf 351
+	#elif defined __powerpc__
+		#define __NR_bpf 361
+	#elif defined __sparc__
+		#define __NR_bpf 349
+	#elif defined __ia64__
+		#define __NR_bpf 317
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_bpf 4355
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_bpf 6319
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_bpf 5315
+		#endif
+	#else
+		#define -1
+		#warning "__NR_bpf not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_pidfd_send_signal
+	#if defined __alpha__
+		#define __NR_pidfd_send_signal 534
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pidfd_send_signal 4424
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pidfd_send_signal 6424
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pidfd_send_signal 5424
+		#endif
+	#else
+		#define __NR_pidfd_send_signal 424
+	#endif
+#endif
+
+#ifndef __NR_pidfd_open
+	#if defined __alpha__
+		#define __NR_pidfd_open 544
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pidfd_open 4434
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pidfd_open 6434
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pidfd_open 5434
+		#endif
+	#else
+		#define __NR_pidfd_open 434
+	#endif
+#endif
+
+#endif /* __LXCFS_SYSCALL_NUMBERS_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,6 +24,7 @@
 
 #include "config.h"
 #include "macro.h"
+#include "syscall_numbers.h"
 
 /* Reserve buffer size to account for file size changes. */
 #define BUF_RESERVE_SIZE 512
@@ -51,11 +52,7 @@ extern int wait_for_pid(pid_t pid);
 #ifndef HAVE_PIDFD_OPEN
 static inline int pidfd_open(pid_t pid, unsigned int flags)
 {
-#ifdef __NR_pidfd_open
 	return syscall(__NR_pidfd_open, pid, flags);
-#else
-	return ret_errno(ENOSYS);
-#endif
 }
 #endif
 
@@ -63,11 +60,7 @@ static inline int pidfd_open(pid_t pid, unsigned int flags)
 static inline int pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
 				    unsigned int flags)
 {
-#ifdef __NR_pidfd_send_signal
 	return syscall(__NR_pidfd_send_signal, pidfd, sig, info, flags);
-#else
-	return ret_errno(ENOSYS);
-#endif
 }
 #endif
 


### PR DESCRIPTION
The same thing that I did for LXC.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>