### PR TITLE
cgroups: more cgroup2 fun

### DIFF
--- a/src/cgroups/cgroup.c
+++ b/src/cgroups/cgroup.c
@@ -72,6 +72,9 @@ void cgroup_exit(struct cgroup_ops *ops)
 	if (ops->mntns_fd >= 0)
 		close(ops->mntns_fd);
 
+	if (ops->cgroup2_root_fd >= 0)
+		close(ops->cgroup2_root_fd);
+
 	free(ops->hierarchies);
 
 	free(ops);

--- a/src/cgroups/cgroup.h
+++ b/src/cgroups/cgroup.h
@@ -91,6 +91,12 @@ struct cgroup_ops {
 	 */
 	int mntns_fd;
 
+	/*
+	 * A file descriptor to the root of the cgroup tree if we're on a
+	 * cgroup2 only system.
+	 */
+	int cgroup2_root_fd;
+
 	/* string constant */
 	const char *driver;
 

--- a/src/cgroups/cgroup_utils.h
+++ b/src/cgroups/cgroup_utils.h
@@ -95,6 +95,10 @@ static inline int openat_safe(int fd, const char *path)
 	return openat(fd, path, O_DIRECTORY | O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
 }
 
+extern int cgroup_walkup_to_root(int cgroup2_root_fd, int hierarchy_fd,
+				 const char *cgroup, const char *file,
+				 char **value);
+
 #define must_make_path_relative(__first__, ...)                                \
 	({                                                                     \
 		char *__ptr__;                                                 \
@@ -104,5 +108,10 @@ static inline int openat_safe(int fd, const char *path)
 			__ptr__ = must_make_path(__first__, __VA_ARGS__);      \
 		__ptr__;                                                       \
 	})
+
+static inline bool is_empty_string(const char *s)
+{
+	return !s || strcmp(s, "") == 0;
+}
 
 #endif /* __LXC_CGROUP_UTILS_H */

--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -1093,6 +1093,9 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 		memset(lbuf, 0, 100);
 		if (startswith(line, "MemTotal:")) {
 			sscanf(line+sizeof("MemTotal:")-1, "%" PRIu64, &hosttotal);
+			if (memlimit == 0)
+				memlimit = hosttotal;
+
 			if (hosttotal < memlimit)
 				memlimit = hosttotal;
 			snprintf(lbuf, 100, "MemTotal:       %8" PRIu64 " kB\n", memlimit);

--- a/tests/test_readdir
+++ b/tests/test_readdir
@@ -20,10 +20,12 @@ if ! mountpoint -q ${LXCFSDIR}; then
     exit 1
 fi
 
-echo "==> Checking for cpuset cgroups"
-[ ! -d /sys/fs/cgroup/cpuset ] && exit 0
-
 TESTCASE="Stress readdir"
-for i in `seq 1 1000`;do ls -al "${LXCFSDIR}/cgroup/cpuset" >/dev/null; done
+echo "==> Checking for cpuset cgroups"
+if [ -d /sys/fs/cgroup/cpuset ]; then
+   for i in `seq 1 1000`;do ls -al "${LXCFSDIR}/cgroup/cpuset" >/dev/null; done
+else
+   echo "==> Skipping $TESTCASE"
+fi
 
 PASS=1


### PR DESCRIPTION
Try too read a valid value from a given cgroup file. If it is a legacy
cgroup hierarchy and we fail to find a valid value we terminate early
and report an error.
The cgroup2 hierarchy however, has different semantics. In a few
controller files it will show the value "max" or simply leave it
completely empty thereby indicating that no limit has been set for this
particular cgroup.  However, that doesn't mean that there's no limit. A
cgroup further up the hierarchy could have a limit set that also applies
to the cgroup we are interested in. So for the unified cgroup hierarchy
we need to keep walking towards the cgroup2 root cgroup and try to parse
a valid value.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>