### PR TITLE
proc_fuse: silence error when we find no memlimit

### DIFF
--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -210,7 +210,7 @@ static uint64_t get_memlimit(const char *cgroup, bool swap)
 		ret = cgroup_ops->get_memory_swap_max(cgroup_ops, cgroup, &memlimit_str);
 	else
 		ret = cgroup_ops->get_memory_max(cgroup_ops, cgroup, &memlimit_str);
-	if (ret > 0 && safe_uint64(memlimit_str, &memlimit, 10) < 0)
+	if (ret > 0 && memlimit_str[0] && safe_uint64(memlimit_str, &memlimit, 10) < 0)
 		lxcfs_error("Failed to convert memlimit %s", memlimit_str);
 
 	return memlimit;


### PR DESCRIPTION
We get a positive result with an empty string if we do not
encounter any limits while walking up the cgroup.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>