### PR TITLE
sysfs: cpuinfo: show cgroup cpuset value

### DIFF
--- a/src/sysfs_fuse.c
+++ b/src/sysfs_fuse.c
@@ -96,12 +96,16 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 	if (use_view)
 		max_cpus = max_cpu_count(cg);
 
-	if (max_cpus == 0)
+	if (use_view) {
+		if (max_cpus > 1)
+			total_len = snprintf(d->buf, d->buflen, "0-%d\n", max_cpus - 1);
+		else
+			total_len = snprintf(d->buf, d->buflen, "0\n");
+	} else if (cpuset) {
+		total_len = snprintf(d->buf, d->buflen, "%s\n", cpuset);
+	} else {
 		return read_file_fuse("/sys/devices/system/cpu/online", buf, size, d);
-	if (max_cpus > 1)
-		total_len = snprintf(d->buf, d->buflen, "0-%d\n", max_cpus - 1);
-	else
-		total_len = snprintf(d->buf, d->buflen, "0\n");
+	}
 	if (total_len < 0 || total_len >= d->buflen)
 		return log_error(0, "Failed to write to cache");
 

--- a/tests/test_proc
+++ b/tests/test_proc
@@ -49,6 +49,9 @@ echo "==> Testing /proc/cpuinfo"
 [ "$(grep "^processor" ${LXCFSDIR}/proc/cpuinfo | wc -l)" = "1" ]
 grep -q "^processor.*0$" ${LXCFSDIR}/proc/cpuinfo || grep -q "^processor 0:.*" ${LXCFSDIR}/proc/cpuinfo
 
+echo "==> Testing /sys/devices/system/cpu/online"
+[ "$(cat ${LXCFSDIR}/sys/devices/system/cpu/online)" = "$(cat ${cpupath}/lxcfs_test_proc/cpuset.cpus)" ]
+
 # Test stat
 echo "==> Testing /proc/stat"
 [ "$(grep "^cpu" ${LXCFSDIR}/proc/stat | wc -l)" = "2" ]


### PR DESCRIPTION
To stop the immediate bleeding.

Closes #401.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>