### PR TITLE
fix epoll create socket error message

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -188,7 +188,7 @@ bool wait_for_sock(int sock, int timeout)
 
 	epfd = epoll_create(1);
 	if (epfd < 0)
-		return log_error(false, "%s\n", "Failed to create epoll socket: %m");
+		return log_error(false, "%m - Failed to create epoll socket");
 
 	ev.events = POLLIN_SET;
 	ev.data.fd = sock;


### PR DESCRIPTION
The epoll socket create error message fails to expand errno, leading to log output like this:

```
Sep 02 05:48:46 hex-128c1-pm lxcfs[2952544]: utils.c: 188: wait_for_sock: Failed to create epoll socket: %m
Sep 02 05:48:46 hex-128c1-pm lxcfs[2952544]: utils.c: 244: recv_creds: Timed out waiting for scm_cred: Too many open files
Sep 02 05:48:46 hex-128c1-pm lxcfs[2057266]: utils.c: 188: wait_for_sock: Failed to create epoll socket: %m
Sep 02 05:48:46 hex-128c1-pm lxcfs[2057266]: utils.c: 280: send_creds: Too many open files - Failed getting reply from server over socketpair: 2
```