### PR TITLE
travis: test with fuse3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get -y install -qq automake coreutils libfuse-dev libtool uuid-runtime
+ - sudo apt-get -y install -qq automake coreutils libfuse3-dev libtool uuid-runtime
 
 script:
  - ./bootstrap.sh


### PR DESCRIPTION
We've recently enabled LXCFS to work with fuse3. Switch our test builds
to it.

Link: https://github.com/lxc/lxcfs/pull/426
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>