### PR TITLE
Rework swap memory management

### DIFF
--- a/src/cgroups/cgfsng.c
+++ b/src/cgroups/cgfsng.c
@@ -620,6 +620,12 @@ static int cgfsng_get_memory_max(struct cgroup_ops *ops, const char *cgroup,
 	return cgfsng_get_memory(ops, cgroup, "memory.max", value);
 }
 
+static int cgfsng_get_memory_swappiness(struct cgroup_ops *ops, const char *cgroup,
+				 char **value)
+{
+	return cgfsng_get_memory(ops, cgroup, "memory.swappiness", value);
+}
+
 static int cgfsng_get_memory_swap_max(struct cgroup_ops *ops,
 				      const char *cgroup, char **value)
 {
@@ -1011,6 +1017,7 @@ struct cgroup_ops *cgfsng_ops_init(void)
 	cgfsng_ops->get_memory_stats_fd = cgfsng_get_memory_stats_fd;
 	cgfsng_ops->get_memory_stats = cgfsng_get_memory_stats;
 	cgfsng_ops->get_memory_max = cgfsng_get_memory_max;
+	cgfsng_ops->get_memory_swappiness = cgfsng_get_memory_swappiness;
 	cgfsng_ops->get_memory_swap_max = cgfsng_get_memory_swap_max;
 	cgfsng_ops->get_memory_current = cgfsng_get_memory_current;
 	cgfsng_ops->get_memory_swap_current = cgfsng_get_memory_swap_current;

--- a/src/cgroups/cgroup.h
+++ b/src/cgroups/cgroup.h
@@ -151,6 +151,8 @@ struct cgroup_ops {
 				       const char *cgroup, char **value);
 	int (*get_memory_max)(struct cgroup_ops *ops, const char *cgroup,
 			      char **value);
+	int (*get_memory_swappiness)(struct cgroup_ops *ops, const char *cgroup,
+			      char **value);
 	int (*get_memory_swap_max)(struct cgroup_ops *ops, const char *cgroup,
 				   char **value);
 	bool (*can_use_swap)(struct cgroup_ops *ops);

--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -407,7 +407,7 @@ static int proc_swaps_read(char *buf, size_t size, off_t offset,
 	if (swtotal > 0) {
 		l = snprintf(d->buf + total_len, d->size - total_len,
 			     "none%*svirtual\t\t%" PRIu64 "\t%" PRIu64 "\t0\n",
-			     36, " ", swtotal, swfree);
+			     36, " ", swtotal, swusage);
 		total_len += l;
 	}
 

--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -325,7 +325,7 @@ static int proc_swaps_read(char *buf, size_t size, off_t offset,
 	bool wants_swap = opts && !opts->swap_off && liblxcfs_can_use_swap();
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
 	uint64_t memswlimit = 0, memlimit = 0, memusage = 0, memswusage = 0,
-		 swtotal = 0, swfree = 0, swusage = 0, memswpriority = 1
+		 swtotal = 0, swusage = 0, memswpriority = 1,
 		 hostswtotal = 0, hostswfree = 0;
 	ssize_t total_len = 0;
 	ssize_t l = 0;
@@ -383,8 +383,6 @@ static int proc_swaps_read(char *buf, size_t size, off_t offset,
 					swusage = 0;
 				else
 					swusage = (memswusage - memusage) / 1024;
-				if (swtotal >= swusage)
-					swfree = swtotal - swusage;
 			}
 
 			ret = cgroup_ops->get_memory_swappiness(cgroup_ops, cgroup, &memswpriority_str);


### PR DESCRIPTION
This lines up LXCFS with what's described in the README.

Also fixes a few bugs in how `/proc/swaps` was handled.