### PR TITLE
proc_fuse: don't spam log needlessly

### DIFF
--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -1015,9 +1015,8 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 
 			if (all_used >= cg_used) {
 				new_idle = idle + (all_used - cg_used);
-
 			} else {
-				lxcfs_error("cpu%d from %s has unexpected cpu time: %" PRIu64 " in /proc/stat, %" PRIu64 " in cpuacct.usage_all; unable to determine idle time",
+				lxcfs_debug("cpu%d from %s has unexpected cpu time: %" PRIu64 " in /proc/stat, %" PRIu64 " in cpuacct.usage_all; unable to determine idle time",
 					    curcpu, cg, all_used, cg_used);
 				new_idle = idle;
 			}


### PR DESCRIPTION
Fixes: https://discuss.linuxcontainers.org/t/lxcfs-spamming-syslog-with-logs-lxc-payload-container-has-unexpected-cpu-time-unable-to-determine-idle-time
Fixes: https://github.com/lxc/lxcfs/issues/464
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>