### PR TITLE
Fix padding for Slab entry in /proc/meminfo

### DIFF
--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -1281,7 +1281,7 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 			snprintf(lbuf, 100, "SwapFree:       %8" PRIu64 " kB\n", swfree);
 			printme = lbuf;
 		} else if (startswith(line, "Slab:")) {
-			snprintf(lbuf, 100, "Slab:        %8" PRIu64 " kB\n", (uint64_t)0);
+			snprintf(lbuf, 100, "Slab:           %8" PRIu64 " kB\n", (uint64_t)0);
 			printme = lbuf;
 		} else if (startswith(line, "Buffers:")) {
 			snprintf(lbuf, 100, "Buffers:        %8" PRIu64 " kB\n", (uint64_t)0);


### PR DESCRIPTION
The padding used for the 'Slab' entry of /proc/meminfo is three bytes
shorter than the padding used by the kernel. Since we report the host's
file size as the size of the lxcfs file, this means reads would be three
bytes short of the reported file length. In some cases this causes the
client to receive three additional NUL bytes at the end of the file,
which can cause various problems.

Signed-off-by: Matthew Stickney <fiendishlinux@gmail.com>