### PR TITLE
meson: Include lxcfs_fuse.h into source files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -182,6 +182,7 @@ liblxcfs_sources = files(
 	'src/cpuset_parse.c',
 	'src/cpuset_parse.h',
 	'src/lxcfs.c',
+	'src/lxcfs_fuse.h',
 	'src/lxcfs_fuse_compat.h',
 	'src/macro.h',
 	'src/memory_utils.h',


### PR DESCRIPTION
I assume this is why the file is missing from the release tarballs :)

Signed-off-by: Morten Linderud <morten@linderud.pw>