### PR TITLE
make meminfo and swaps cgroupv2 aware

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -44,6 +44,7 @@ static bool can_use_pidfd;
 static bool can_use_swap;
 static bool can_use_sys_cpu;
 static bool has_versioned_opts;
+static bool memory_is_cgroupv2;
 
 static volatile sig_atomic_t reload_successful;
 
@@ -65,6 +66,11 @@ bool liblxcfs_can_use_sys_cpu(void)
 bool liblxcfs_has_versioned_opts(void)
 {
 	return has_versioned_opts;
+}
+
+bool liblxcfs_memory_is_cgroupv2(void)
+{
+	return memory_is_cgroupv2;
 }
 
 /* Define pivot_root() if missing from the C library */
@@ -837,6 +843,7 @@ static void __attribute__((constructor)) lxcfs_init(void)
 				  pidfd = -EBADF;
 	int i = 0;
 	pid_t pid;
+	struct hierarchy *hierarchy;
 
 	lxcfs_info("Running constructor %s to reload liblxcfs", __func__);
 
@@ -893,6 +900,9 @@ static void __attribute__((constructor)) lxcfs_init(void)
 		lxcfs_info("Kernel supports swap accounting");
 	else
 		lxcfs_info("Kernel does not support swap accounting");
+
+	hierarchy = cgroup_ops->get_hierarchy(cgroup_ops, "memory");
+	memory_is_cgroupv2 = hierarchy && is_unified_hierarchy(hierarchy);
 
 	lxcfs_info("api_extensions:");
 	for (size_t nr = 0; nr < nr_api_extensions; nr++)

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -104,6 +104,7 @@ extern void prune_init_slice(char *cg);
 extern bool supports_pidfd(void);
 extern bool liblxcfs_functional(void);
 extern bool liblxcfs_can_use_swap(void);
+extern bool liblxcfs_memory_is_cgroupv2(void);
 extern bool liblxcfs_can_use_sys_cpu(void);
 extern bool liblxcfs_has_versioned_opts(void);
 


### PR DESCRIPTION
Also deduplicates some common code there.

An alternative to the cgv2 check inside `proc_fuse.c` would be to move the mem/swap/memsw-sum logic into the cgroup ops, not sure if it's worth it.