### PR TITLE
Preseve cpu sum in /proc/stat when cpuset changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ lxcfs-*.tar.gz
 *.la
 .vscode
 src/cgroups/.dirstamp
+.idea/


### PR DESCRIPTION
## Why

- For issue https://github.com/lxc/lxcfs/issues/513
- Currently, value in /proc/stat will be reset when cpuset of the cgroup is updated

## How

- Total cpu usage shown for the cgroup will always be the sum of all actual CPUs, regardless of the active/inactive CPUs
- CPU time of individual "rendered"/"virtual" CPUs for the cgroup will be split according to the online CPUs, such that the sum of all "rendered"/"virtual" CPUs will add up to the cgroup's sum cpu usage (1st line in /proc/stat)
- When cpuset/cfs_quota_us of the cgroup is changed, the cpu time of each core might be resetted (can't avoid for now, since the number of "rendered"/"virtual" CPUs can be changed), but the sum cpu time is unchanged.
- Detailed formula is in the comment of the code change

## Test cases

### 1. VM with 2 CPUs

- Screencast
[![asciicast](https://asciinema.org/a/465583.svg)](https://asciinema.org/a/465583)

- Start a container with: cfs_quota_us = 50000, cfs_period_us = 100000, cpu.cpusets = 0
- Change cpu.cpusets from 0 -> 1: cputime not reset
- Change back cpu.cpusets from 1 -> 0: cputime not reset
- Change back cpu.cpusets from 0 -> 0,1: cputime not reset
- Change cfs_quota_us: 50000 -> 200000: 2 cpus shown
- Change back cpu.cpusets from 0, 1 -> 0: cputime of cpu 1 is added to virtual cpu 0
- Change back cpu.cpusets from 0 -> 0, 1: cputime split between 0 and 1
- Change back cpu.cpusets from 0, 1 -> 1: cputime added to virtual cpu 0
- Change cfs_quota_us: 200000 -> -1 (max cpus unchanged): cputime not affected

### 2. Bare metal with 48 CPUs

- Start a container with: cfs_quota_us=-1, cpu.cpusets=0-47, cfs_period_us=100000

<img width="376" alt="Screenshot 2022-01-31 at 12 46 00 PM" src="https://user-images.githubusercontent.com/7282697/151742749-82769812-6482-4024-a629-dade6fac35a1.png">

- Change cpu.cpusets from 0-47 -> 0-10: cpu time not reset, cpu time of cpu11->47 is added to cpu10

<img width="330" alt="Screenshot 2022-01-31 at 12 46 11 PM" src="https://user-images.githubusercontent.com/7282697/151742779-d31625a7-63c1-47f3-be10-166409403294.png">

- Change cpu.cpusets from 0-10 ->  0,5,6,7,12,1: cpu time not reset, cpu time of each cpu is re-distributed

<img width="315" alt="Screenshot 2022-01-31 at 12 47 15 PM" src="https://user-images.githubusercontent.com/7282697/151742839-fd1bc9aa-1278-4770-ab1b-c7e4ff19da9e.png">

- Change cfs_quota_us -1 -> 200000 (= x2 cfs_period_us): /proc/stat shows 2 virtual CPUs. Sum cpu time unchanged

<img width="324" alt="Screenshot 2022-01-31 at 12 50 32 PM" src="https://user-images.githubusercontent.com/7282697/151742896-393e4be6-913a-41fd-b6d0-53bcb8a7a804.png">

Signed-off-by: Nguyen Phan Huy phanhuy1502@gmail.com