### PR TITLE
init/meson: Use libdir instead of hardcoded /lib path

### DIFF
--- a/config/init/meson.build
+++ b/config/init/meson.build
@@ -12,7 +12,7 @@ if init_script == 'systemd'
             '@OUTPUT@',
         ],
         install: true,
-        install_dir: '/lib/systemd/system')
+        install_dir: join_paths(libdir, 'systemd/system'))
 
 elif init_script == 'upstart'
         install_data('upstart/lxcfs.conf', install_dir: join_paths(sysconfdir, 'init'))


### PR DESCRIPTION
Hardcoding `/lib` makes meson create a directory which would conflict on
distros with usrmerge as `/lib` is a symlink. We define `libdir` in the
top-level so we should be using that instead.

Signed-off-by: Morten Linderud <morten@linderud.pw>