### PR TITLE
support explicit fuse version choice

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -146,22 +146,31 @@ foreach ident: [
     conf.set10('HAVE_' + ident[0].to_upper(), have)
 endforeach
 
-libfuse = dependency('fuse3', required: false)
-if libfuse.found()
-    conf.set10('HAVE_FUSE3', true)
-    conf.set('FUSE_USE_VERSION', 35)
-    if libfuse.version().version_compare('>=3.10.3')
-	conf.set10('HAVE_FUSE_RETURNS_DT_TYPE', true)
-    else
-	conf.set10('HAVE_FUSE_RETURNS_DT_TYPE', false)
+fuse_version = get_option('fuse-version')
+if fuse_version == '3' or fuse_version == 'auto'
+    libfuse = dependency('fuse3', required: false)
+    if libfuse.found()
+        conf.set10('HAVE_FUSE3', true)
+        conf.set('FUSE_USE_VERSION', 35)
+        if libfuse.version().version_compare('>=3.10.3')
+            conf.set10('HAVE_FUSE_RETURNS_DT_TYPE', true)
+        else
+            conf.set10('HAVE_FUSE_RETURNS_DT_TYPE', false)
+        endif
     endif
-else
+endif
+
+if fuse_version == '2' or (not libfuse.found() and fuse_version == 'auto')
     libfuse = dependency('fuse', version: '>= 2.6')
     if libfuse.found()
         conf.set10('HAVE_FUSE', true)
         conf.set('FUSE_USE_VERSION', 26)
-	conf.set10('HAVE_FUSE_RETURNS_DT_TYPE', true)
+        conf.set10('HAVE_FUSE_RETURNS_DT_TYPE', true)
     endif
+endif
+
+if not libfuse.found()
+	error('no usable fuse version found')
 endif
 
 libdl = cc.find_library('dl')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,3 +15,7 @@ option('init-script', type : 'combo',
 
 option('docs', type : 'boolean', value: 'true',
        description : 'build documentation')
+
+option('fuse-version', type : 'combo',
+       choices : ['auto', '2', '3'], value : 'auto',
+       description : 'fuse version to use')


### PR DESCRIPTION
We'd like to provide an easy upgrade path which doesn't
cause an lxcfs-reload to crash because the new library was
built against the wrong version.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>