### PR TITLE
proc_fuse: extra space in /proc/stat

### DIFF
--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -1091,7 +1091,7 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 	int cpuall_len = snprintf(
 			cpuall,
 			CPUALL_MAX_SIZE,
-			"cpu  "
+			"cpu "
 			" %" PRIu64 /* user_sum */
 			" %" PRIu64 /* nice_sum */
 			" %" PRIu64 /* system_sum */


### PR DESCRIPTION
on lxc

	$ head -2 /proc/stat 
	cpu   12846 0 3181 19349 511 122 59 0 0 0
	cpu0 2909 0 787 5126 157 32 14 0 0 0

on host

	$ head -2 /proc/stat 
	cpu  13271 0 3449 33618 565 176 96 0 0 0
	cpu0 3012 0 854 8685 171 48 25 0 0 0

Signed-off-by: Tuomas Yrjölä <mail@yrhki.fi>