### PR TITLE
cgroup v2: /sys/devices/system/cpu/online returns zero

### DIFF
--- a/src/proc_cpuview.c
+++ b/src/proc_cpuview.c
@@ -466,7 +466,7 @@ static bool cfs_quota_disabled(const char *cg)
 
 /*
  * Return the maximum number of visible CPUs based on CPU quotas.
- * If there is no quota set, zero is returned.
+ * If there is no quota set, cpu number in cpuset value is returned.
  */
 int max_cpu_count(const char *cg)
 {
@@ -476,10 +476,10 @@ int max_cpu_count(const char *cg)
 	int nr_cpus_in_cpuset = 0;
 
 	if (!read_cpu_cfs_param(cg, "quota", &cfs_quota))
-		return 0;
+		cfs_quota = 0;
 
 	if (!read_cpu_cfs_param(cg, "period", &cfs_period))
-		return 0;
+		cfs_period = 0;
 
 	cpuset = get_cpuset(cg);
 	if (cpuset)


### PR DESCRIPTION
lxcfs `sys/devices/system/cpu/online` returns 0, when cgroup v2 is enabled and run with `--enable-cfs` and cpu quota is not set.

In cgroup v2, the first column of cpu.max will be a string: "max" if no cpu quota is set. `read_cpu_cfs_param --> sscanf` function fails to parse `"max"` as a number and return zero cpu count.
If cpu controller is not enabled, there is no `cpu.max` file in cgroup dir. It also lead to `max_cpu_count` func returns zero.

https://github.com/lxc/lxcfs/blob/lxcfs-5.0.0/src/proc_cpuview.c#L422
https://github.com/lxc/lxcfs/blob/lxcfs-5.0.0/src/proc_cpuview.c#L479

In cgroup v1, if `cfs_quota_us = -1`, `max_cpu_count` returns cpu count in cpuset: 
https://github.com/lxc/lxcfs/blob/lxcfs-5.0.0/src/proc_cpuview.c#L489

This patch will fix this bug for cgroup v2 env.