### PR TITLE
replace opathdir with opendir_flags

### DIFF
--- a/src/sysfs_fuse.c
+++ b/src/sysfs_fuse.c
@@ -596,7 +596,7 @@ __lxcfs_fuse_ops int sys_readdir(const char *path, void *buf,
 
 		return filler_sys_devices_system_cpu(path, buf, filler);
 	case LXC_TYPE_SYS_DEVICES_SYSTEM_CPU_SUBDIR:
-		dirp = opathdir(path);
+		dirp = opendir_flags(path, O_CLOEXEC | O_NOFOLLOW);
 		if (!dirp)
 			return -errno;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -627,12 +627,12 @@ char *read_file_at(int dfd, const char *fnam, unsigned int o_flags)
 	return move_ptr(buf);
 }
 
-DIR *opathdir(const char *path)
+DIR *opendir_flags(const char *path, int flags)
 {
 	__do_close int dfd = -EBADF;
 	DIR *dirp;
 
-	dfd = open(path, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
+	dfd = open(path, O_DIRECTORY | flags);
 	if (dfd < 0)
 		return NULL;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -59,7 +59,7 @@ static inline int pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
 extern FILE *fopen_cached(const char *path, const char *mode,
 			  void **caller_freed_buffer);
 extern FILE *fdopen_cached(int fd, const char *mode, void **caller_freed_buffer);
-extern DIR *opathdir(const char *path);
+extern DIR *opendir_flags(const char *path, int oflags);
 extern ssize_t write_nointr(int fd, const void *buf, size_t count);
 extern int safe_uint64(const char *numstr, uint64_t *converted, int base);
 extern char *trim_whitespace_in_place(char *buffer);


### PR DESCRIPTION
`opathdir` was used to replace `opendir` in order to ensure
`O_NOFOLLOW` and `O_CLOEXEC` were set, however it also added
`O_PATH` which prevents `readdir`/`getdents` to be used on
it, causing the `/sys/devices/system/cpu/<subdir>`
directories to be empty.

Instead, let's have an `opendir_flags` utility which simply
passed additional flags to the `open(..., O_DIRECTORY)` call
preceding `fdopendir()`.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>