### PR TITLE
set oom_score_adj of lxcfs process to -1000

### DIFF
--- a/config/init/systemd/lxcfs.service.in
+++ b/config/init/systemd/lxcfs.service.in
@@ -5,6 +5,7 @@ Before=lxc.service
 Documentation=man:lxcfs(1)
 
 [Service]
+OOMScoreAdjust=-1000
 ExecStart=/usr/bin/lxcfs {{LXCFSTARGETDIR}}
 KillMode=process
 Restart=on-failure

--- a/config/init/sysvinit/lxcfs
+++ b/config/init/sysvinit/lxcfs
@@ -16,6 +16,7 @@ DAEMON=/usr/bin/lxcfs
 NAME=lxcfs
 DESC="FUSE filesystem for LXC"
 PIDFILE=/var/run/lxcfs.pid
+OOM_SCORE_ADJ="-1000"
 
 . /lib/lsb/init-functions
 
@@ -41,6 +42,7 @@ case "$1" in
         echo -n "Starting $DESC: "
         if start-stop-daemon ${START} -- /var/lib/lxcfs >/dev/null 2>&1 ; then
             echo "${NAME}."
+            echo ${OOM_SCORE_ADJ} > /proc/`cat ${PIDFILE}`/oom_score_adj
         else
             if start-stop-daemon --test ${START} >/dev/null 2>&1; then
                 echo "(failed)."

--- a/config/init/upstart/lxcfs.conf
+++ b/config/init/upstart/lxcfs.conf
@@ -4,6 +4,7 @@ author "Stéphane Graber <stgraber@ubuntu.com>"
 start on starting lxc or starting lxd or runlevel [2345]
 stop on runlevel [06]
 
+oom score -1000
 respawn
 
 pre-start script


### PR DESCRIPTION
Disable oom killing entirely to minimize the hassle comes from
lxcfs exiting unexpectedly, e.g. the mountpoint got lost.

Signed-off-by: Teng Hu <huteng.ht@bytedance.com>