### PR TITLE
/proc/stat: render physical cpu number in non-view mode

### DIFF
--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -972,7 +972,7 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 		char cpu_char[10]; /* That's a lot of cores */
 		char *c;
 		uint64_t all_used, cg_used, new_idle;
-		int ret;
+		int ret, cpu_to_render;
 
 		if (strlen(line) == 0)
 			continue;
@@ -998,6 +998,11 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 			continue;
 
 		curcpu++;
+
+		if (cgroup_ops->can_use_cpuview(cgroup_ops) && opts && opts->use_cfs)
+			cpu_to_render = curcpu;
+		else
+			cpu_to_render = physcpu;
 
 		ret = sscanf(
 			   line,
@@ -1027,7 +1032,7 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 			if (!c)
 				continue;
 
-			l = snprintf(cache, cache_size, "cpu%d%s", curcpu, c);
+			l = snprintf(cache, cache_size, "cpu%d%s", cpu_to_render, c);
 			if (l < 0)
 				return log_error(0, "Failed to write cache");
 			if ((size_t)l >= cache_size)
@@ -1052,13 +1057,13 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 				new_idle = idle + (all_used - cg_used);
 			} else {
 				lxcfs_debug("cpu%d from %s has unexpected cpu time: %" PRIu64 " in /proc/stat, %" PRIu64 " in cpuacct.usage_all; unable to determine idle time",
-					    curcpu, cg, all_used, cg_used);
+					    cpu_to_render, cg, all_used, cg_used);
 				new_idle = idle;
 			}
 
 			l = snprintf(cache, cache_size,
 				     "cpu%d %" PRIu64 " 0 %" PRIu64 " %" PRIu64 " 0 0 0 0 0 0\n",
-				     curcpu, cg_cpu_usage[physcpu].user,
+				     cpu_to_render, cg_cpu_usage[physcpu].user,
 				     cg_cpu_usage[physcpu].system, new_idle);
 			if (l < 0)
 				return log_error(0, "Failed to write cache");


### PR DESCRIPTION
When the kernel has an offline CPU, it only renders the online CPUs in /proc/stat.

When in non-use_view mode, /sys/devices/system/cpu/online shows the CPU numbers as they actually are on the physical system, but /proc/stat used "virtual" (i.e. always zero-indexed) numbers, which causes confusion for some applications. Let's use the same use_view logic in /proc/stat as well.

(root) ~ # chcpu -d 4
CPU 4 disabled
(root) ~ # cat /sys/devices/system/cpu/online
0-3,5-7
(root) ~ # cat /proc/stat
cpu  5599257 116799 1924319 150675607 147630 0 51038 2454 0 0 cpu0 664385 19911 221078 19009148 14812 0 9832 2238 0 0 cpu1 783128 16478 282310 18416428 14325 0 6287 27 0 0 cpu2 822527 15344 275820 18355637 11215 0 5762 26 0 0 cpu3 807309 15631 277152 18399668 9697 0 7623 27 0 0 cpu5 712191 13680 245495 20759989 13959 0 6968 46 0 0 cpu6 728409 14828 247631 20794157 40037 0 5624 29 0 0 cpu7 709679 14321 251154 20785870 18872 0 6226 32 0 0 intr 10891106673 0 10 0 0 418 0 0 0 0 1 0 0 3 0 0 0 0 0 0 0 0 0 0 0 8 8 406552 434812 1863708 2335638 258448 3878047 1907518 1500768 1860249 1506066 1743056 1527121 1564894 258398 779468 275941 275383 277085 271838 271729 273211 271677 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ctxt 814064094
btime 1666730552
processes 5152733
procs_running 1
procs_blocked 0
softirq 772324623 4 31396133 263035 39649581 20 4 1593903 442777055 51 256644837

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>