### PR TITLE
Fix build on ia64

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -424,7 +424,7 @@ __returns_twice pid_t lxcfs_raw_clone(unsigned long flags, int *pidfd)
 	}
 #elif defined(__ia64__)
 	/* On ia64 the stack and stack size are passed as separate arguments. */
-	return syscall(__NR_clone, flags | SIGCHLD, NULL, prctl_arg(0), pidfd);
+	return syscall(__NR_clone, flags | SIGCHLD, NULL, 0, pidfd);
 #else
 	return syscall(__NR_clone, flags | SIGCHLD, NULL, pidfd);
 #endif


### PR DESCRIPTION
The relevant code was added in commit 35acc24, but the function/macro prctl_arg() didn't seem to be defined anywhere in the repo. lxc currently has a corresponding macro defined in src/lxc/macro.h that casts the value to an unsigned long. But 0 doesn't require any special handling, so remove the call to prctl_arg().

Verified that the code compiles properly on Debian's ia64 porterbox (yttrium).