### PR TITLE
meson: allow not installing init script

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,7 +10,7 @@ option('with-init-script', type : 'string', value : 'systemd',
        description : 'the runtime directory')
 
 option('init-script', type : 'array',
-       choices : ['systemd', 'sysvinit', 'openrc', 'upstart'], value : ['systemd'],
+       choices : ['', 'systemd', 'sysvinit', 'openrc', 'upstart'], value : ['systemd'],
        description : 'init script')
 
 option('docs', type : 'boolean', value: 'true',


### PR DESCRIPTION
Sometimes it's useful to not install an init script, for example if the installed init system is less common (runit in my case). Without this change, the build system installs a service file that then has to be removed manually.