### PR TITLE
Handle NULL in releasedir

### DIFF
--- a/src/lxcfs.c
+++ b/src/lxcfs.c
@@ -771,6 +771,13 @@ static int lxcfs_releasedir(const char *path, struct fuse_file_info *fi)
 {
 	int ret;
 
+        if (path == NULL) {
+                up_users();
+                ret = do_cg_releasedir(path, fi);
+                down_users();
+                return ret;
+        }
+	
 	if (strcmp(path, "/") == 0)
 		return 0;
 
@@ -1032,6 +1039,7 @@ static void *lxcfs_init(struct fuse_conn_info *conn)
 
 #if HAVE_FUSE3
 	cfg->direct_io = 1;
+	cfg->nullpath_ok = 0;
 #endif
 
 	return fuse_get_context()->private_data;


### PR DESCRIPTION
Whilst libfuse seems to indicate this should not occur when `nullpath_ok` is switched off, this does not always seem to be the case. A straightforward workaround is to handle the NULL case of `path` in `lxcfs_releasedir` such that no crash can occur in snaps.

Example crash we caught a few days ago:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fa33020bbee in ?? () at ../sysdeps/x86_64/multiarch/strcpy-evex.S:933 from /lib/x86_64-linux-gnu/libc.so.6
933     ../sysdeps/x86_64/multiarch/strcpy-evex.S: No such file or directory.
lxc/lxd#1  0x0000564ac32ea508 in lxcfs_releasedir (path=0x0, fi=0x7fa30fffec80) at ../src/src/lxcfs.c:774
lxc/lxd#2  0x00007fa3302c62b7 in ?? () from /snap/lxd/current/lib/x86_64-linux-gnu/libfuse3.so.3
lxc/lxd#3  0x00007fa3302cd683 in ?? () from /snap/lxd/current/lib/x86_64-linux-gnu/libfuse3.so.3
lxc/lxd#4  0x00007fa3302cfc59 in ?? () from /snap/lxd/current/lib/x86_64-linux-gnu/libfuse3.so.3
lxc/lxd#5  0x00007fa3302cb407 in ?? () from /snap/lxd/current/lib/x86_64-linux-gnu/libfuse3.so.3
lxc/lxd#6  0x00007fa33029d609 in ?? ()
lxc/lxd#7  0x0000000000000000 in ?? ()
```

Signed-off-by: Matthew Ife <75210448+deleriux@users.noreply.github.com>