### PR TITLE
build: tools: keep trailing newline in jinja2 renderer

### DIFF
--- a/tools/meson-render-jinja2.py
+++ b/tools/meson-render-jinja2.py
@@ -23,7 +23,12 @@ def parse_config_h(filename):
 
 def render(filename, defines):
     text = open(filename).read()
-    template = jinja2.Template(text, trim_blocks=True, undefined=jinja2.StrictUndefined)
+    template = jinja2.Template(
+        text,
+        trim_blocks=True,
+        keep_trailing_newline=True,
+        undefined=jinja2.StrictUndefined,
+    )
     return template.render(defines)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Otherwise /usr/share/lxc/config/common.conf.d/00-lxcfs.conf loses its trailing newline

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>