### PR TITLE
Revert "init: respect --prefix when installing systemd unit files"

### DIFF
--- a/config/init/meson.build
+++ b/config/init/meson.build
@@ -2,7 +2,7 @@
 
 if 'systemd' in init_script
     systemd = dependency('systemd')
-    systemd_system_unit_dir = get_option('prefix') + systemd.get_pkgconfig_variable('systemdsystemunitdir')
+    systemd_system_unit_dir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
     systemd_service = custom_target(
         'lxcfs.service',
         input: 'systemd/lxcfs.service.in',


### PR DESCRIPTION
This reverts commit 9bfc897a0c6b010464dc490e955dbc1d1a66e4c3.

Reported to be causing issues in #555

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>