### PR TITLE
 cpuset cgroup path maybe different from cpu cgroup path in kubernetes

### DIFF
--- a/src/proc_cpuview.h
+++ b/src/proc_cpuview.h
@@ -21,7 +21,7 @@ struct cpuacct_usage {
 	bool online;
 };
 
-extern int cpuview_proc_stat(const char *cg, const char *cpuset,
+extern int cpuview_proc_stat(const char *cg, const char *cpu_cg, const char *cpuset,
 			     struct cpuacct_usage *cg_cpu_usage,
 			     int cg_cpu_usage_size, FILE *f, char *buf,
 			     size_t buf_size);
@@ -31,7 +31,7 @@ extern int read_cpuacct_usage_all(char *cg, char *cpuset,
 				  struct cpuacct_usage **return_usage, int *size);
 extern bool init_cpuview(void);
 extern void free_cpuview(void);
-extern int max_cpu_count(const char *cg);
+extern int max_cpu_count(const char *cpuset_cg, const char *cpu_cg);
 
 #endif /* __LXCFS_PROC_CPUVIEW_FUSE_H */
 


### PR DESCRIPTION
lxcfs use cpuset cgroup path to get cpu cgroup cfs_quota, cfs_period info, it works in most usecase.
however, if we deploy lxcfs on kubernetes with containerd runtime, the cpu and cpuset cgroup path is different.
the cpuset cgroup path  use prefix "/kubepods-pod"  while the cpu cgroup path use  prefix "/system.slice/containerd.service/kubepods-" .
in this case, the "/proc/cpuinfo" will be incorrect.

