### PR TITLE
Partial support for FUSE_INTERRUPT

### DIFF
--- a/src/bindings.h
+++ b/src/bindings.h
@@ -92,6 +92,10 @@ enum lxcfs_virt_t {
  */
 #define LXCFS_INTR_SIGNAL SIGTTOU
 
+extern int mutex_lock_interruptible(pthread_mutex_t *l);
+extern int rwlock_rdlock_interruptible(pthread_rwlock_t *l);
+extern int rwlock_wrlock_interruptible(pthread_rwlock_t *l);
+
 struct file_info {
 	char *controller;
 	char *cgroup;

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -78,6 +78,20 @@ enum lxcfs_virt_t {
 #define LXCFS_TYPE_SYS(type) (type >= LXC_TYPE_SYS && type <= LXC_TYPE_SYS_DEVICES_SYSTEM_CPU_ONLINE)
 #define LXCFS_TYPE_OK(type) (type >= LXC_TYPE_CGDIR && type < LXC_TYPE_MAX)
 
+/*
+ * This signal will be used to signal fuse request processing thread that
+ * request was interrupted (FUSE_INTERRUPT came from the kernel).
+ *
+ * It's not imporant which signal num is used, but it should not intersect with
+ * any signals those are already handled and used somewhere.
+ * Since, SIGUSR1 and SIGUSR2 are already utilized by lxcfs, let it be SIGTTOU.
+ *
+ * See also:
+ * ("interrupt support")
+ * https://github.com/libfuse/libfuse/commit/288ed4ebcea335c77793ee3d207c7466d55c4f71
+ */
+#define LXCFS_INTR_SIGNAL SIGTTOU
+
 struct file_info {
 	char *controller;
 	char *cgroup;


### PR DESCRIPTION
Let's start handling `FUSE_INTERRUPT` request in LXCFS.
This may help in a few scenarios:
- when buggy deadlock happens (user will be able to kill processes those are in fuse IO)
- when some fuse file becomes laggy (high lock contention?). We have seen big contention on some locks when kubernetes+monitoring software were used with LXCFS

I'm trying to be conservative and not make global changes at once. Let's just discuss about approach and convert one place at first. Then we will decide if it's helpful or not.