### PR TITLE
support enable-host-diskstats option.

### DIFF
--- a/src/bindings.h
+++ b/src/bindings.h
@@ -93,6 +93,7 @@ struct lxcfs_opts {
 	bool swap_off;
 	bool use_pidfd;
 	bool use_cfs;
+	bool use_host_diskstats;
 	/*
 	 * Ideally we'd version by size but because of backwards compatability
 	 * and the use of bool instead of explicited __u32 and __u64 we can't.
@@ -101,10 +102,11 @@ struct lxcfs_opts {
 };
 
 typedef enum lxcfs_opt_t {
-	LXCFS_SWAP_ON	= 0,
-	LXCFS_PIDFD_ON	= 1,
-	LXCFS_CFS_ON	= 2,
-	LXCFS_OPTS_MAX	= LXCFS_CFS_ON,
+	LXCFS_SWAP_ON        = 0,
+	LXCFS_PIDFD_ON       = 1,
+	LXCFS_CFS_ON         = 2,
+	LXCFS_HOST_DISKSTATS = 3,
+	LXCFS_OPTS_MAX	     = LXCFS_HOST_DISKSTATS,
 } lxcfs_opt_t;
 
 
@@ -135,6 +137,8 @@ static inline bool lxcfs_has_opt(struct lxcfs_opts *opts, lxcfs_opt_t opt)
 		return opts->use_pidfd;
 	case LXCFS_CFS_ON:
 		return opts->use_cfs;
+	case LXCFS_HOST_DISKSTATS:
+		return opts->use_host_diskstats;
 	}
 
 	return false;

--- a/src/lxcfs.c
+++ b/src/lxcfs.c
@@ -1117,17 +1117,18 @@ static void usage(void)
 	lxcfs_info("Usage: lxcfs <directory>\n");
 	lxcfs_info("lxcfs is a FUSE-based proc, sys and cgroup virtualizing filesystem\n");
 	lxcfs_info("Options :");
-	lxcfs_info("  -d, --debug          Run lxcfs with debugging enabled");
-	lxcfs_info("  -f, --foreground     Run lxcfs in the foreground");
-	lxcfs_info("  -n, --help           Print help");
-	lxcfs_info("  -l, --enable-loadavg Enable loadavg virtualization");
-	lxcfs_info("  -o                   Options to pass directly through fuse");
-	lxcfs_info("  -p, --pidfile=FILE   Path to use for storing lxcfs pid");
-	lxcfs_info("                       Default pidfile is %s/lxcfs.pid", RUNTIME_PATH);
-	lxcfs_info("  -u, --disable-swap   Disable swap virtualization");
-	lxcfs_info("  -v, --version        Print lxcfs version");
-	lxcfs_info("  --enable-cfs         Enable CPU virtualization via CPU shares");
-	lxcfs_info("  --enable-pidfd       Use pidfd for process tracking");
+	lxcfs_info("  -d, --debug               Run lxcfs with debugging enabled");
+	lxcfs_info("  -f, --foreground          Run lxcfs in the foreground");
+	lxcfs_info("  -n, --help                Print help");
+	lxcfs_info("  -l, --enable-loadavg      Enable loadavg virtualization");
+	lxcfs_info("  -o                        Options to pass directly through fuse");
+	lxcfs_info("  -p, --pidfile=FILE        Path to use for storing lxcfs pid");
+	lxcfs_info("                            Default pidfile is %s/lxcfs.pid", RUNTIME_PATH);
+	lxcfs_info("  -u, --disable-swap        Disable swap virtualization");
+	lxcfs_info("  -v, --version             Print lxcfs version");
+	lxcfs_info("  --enable-cfs              Enable CPU virtualization via CPU shares");
+	lxcfs_info("  --enable-pidfd            pidfd for process tracking");
+	lxcfs_info("  --enable-host-diskstats   Use host's /proc/diskstats instead of cgroup");
 	exit(EXIT_FAILURE);
 }
 
@@ -1176,6 +1177,7 @@ static const struct option long_options[] = {
 
 	{"enable-cfs",		no_argument,		0,	  0	},
 	{"enable-pidfd",	no_argument,		0,	  0	},
+	{"enable-host-diskstats",	no_argument,		0,	  0	},
 
 	{"pidfile",		required_argument,	0,	'p'	},
 	{								},
@@ -1247,6 +1249,7 @@ int main(int argc, char *argv[])
 	opts->swap_off = false;
 	opts->use_pidfd = false;
 	opts->use_cfs = false;
+	opts->use_host_diskstats = false;
 	opts->version = 1;
 
 	while ((c = getopt_long(argc, argv, "dulfhvso:p:", long_options, &idx)) != -1) {
@@ -1256,6 +1259,8 @@ int main(int argc, char *argv[])
 				opts->use_pidfd = true;
 			else if (strcmp(long_options[idx].name, "enable-cfs") == 0)
 				opts->use_cfs = true;
+			else if (strcmp(long_options[idx].name, "enable-host-diskstats") == 0)
+				opts->use_host_diskstats = true;
 			else
 				usage();
 			break;


### PR DESCRIPTION
## new interface 
`--enable-host-diskstats`

## Experimental procedure
- Disk condition after partition：
```bash
$ lsblk
sdd                8:48   0  100G  0 disk 
├─sdd1             8:49   0   50G  0 part 
├─sdd2             8:50   0    1K  0 part 
└─sdd5             8:53   0   20G  0 part
```
- start lxcfs
```bash
$ lxcfs --enable-host-diskstats /var/lib/lxc/lxcfs/ &
```

- Start the container
```bash
$ docker run -tid -m 256m --device=/dev/sdd1:/dev/test -v /var/lib/lxc/lxcfs/proc/meminfo:/proc/meminfo:rw -v /var/lib/lxc/lxcfs/proc/diskstats:/proc/diskstats:rw --name test ubuntu bash
```
- View container's /proc/diskstats
```bash
$ docker exec -it test ls /dev/test
/dev/test
$ docker exec -it test cat /proc/diskstats
8       49 test 249 0 17928 24 75 1115 535153 152 0 169 180 51 0 104857608 3
$ cat /proc/diskstats 
   8       0 sda 23881 2843 2239558 980807 62612 124673 23769904 27578300 0 1989128 29020938 0 0 0 0 11198 461830
   8      32 sdc 1329 0 20890 1088 5376 71021 5013944 101385 0 52829 168482 21 0 41943048 1 277 66007
   8      48 sdd 1383 0 75670 143 104 1115 536836 643 0 813 1279 51 0 104857608 3 5 488
   8      49 sdd1 249 0 17928 24 75 1115 535153 152 0 169 180 51 0 104857608 3 0 0
   8      50 sdd2 10 0 68 0 0 0 0 0 0 10 0 0 0 0 0 0 0
   8      53 sdd5 312 0 20032 29 22 0 1667 2 0 82 32 0 0 0 0 0 0
```
- delete container
```
docker rm -f `docker ps -aq`
```
After enabling the enable-host-diskstats option, when the user accesses the /proc/diskstats file, the host /proc/diskstats data will be used instead of reading data from the cgroup. This option is suitable for scenarios where the container exclusively uses block/character devices.

fix #599 