### PR TITLE
proc_loadavg.c: Fix incompatible integer to pointer conversion

### DIFF
--- a/src/proc_loadavg.c
+++ b/src/proc_loadavg.c
@@ -636,12 +636,12 @@ pthread_t load_daemon(int load_use)
 
 	ret = init_load();
 	if (ret == -1)
-		return log_error(0, "Initialize hash_table fails in load_daemon!");
+		return (pthread_t)log_error(0, "Initialize hash_table fails in load_daemon!");
 
 	ret = pthread_create(&pid, NULL, load_begin, NULL);
 	if (ret != 0) {
 		load_free();
-		return log_error(0, "Create pthread fails in load_daemon!");
+		return (pthread_t)log_error(0, "Create pthread fails in load_daemon!");
 	}
 
 	/* use loadavg, here loadavg = 1*/


### PR DESCRIPTION
Newer compiler like Clang 16 and GCC 14 have certain error enabled by default, namely -Werror=incompatible-function-pointer-types. Which resutls in build error such as:
```
proc_loadavg.c:606:10: error: incompatible integer to pointer conversion returning int from a function with result type pthread_t
```

My patch supresses the error for now, but a proper fix would be better. Fist discovered on Gentoo linux (bug #894348).

Bug: https://bugs.gentoo.org/894348
Closes: https://github.com/lxc/lxcfs/issues/561