### PR TITLE
cpuview: pass a correct argument to lxcfs_debug

### DIFF
--- a/src/proc_cpuview.c
+++ b/src/proc_cpuview.c
@@ -265,7 +265,7 @@ static struct cg_proc_stat *prune_proc_stat_list(struct cg_proc_stat *node)
 				first = node->next;
 
 			node = node->next;
-			lxcfs_debug("Removing stat node for %s\n", cur);
+			lxcfs_debug("Removing stat node for %s\n", cur->cg);
 
 			free_proc_stat_node(cur);
 		} else {


### PR DESCRIPTION
struct cg_proc_stat *cur;
...
lxcfs_debug("Removing stat node for %s\n", cur);

should be:

lxcfs_debug("Removing stat node for %s\n", cur->cg);

Only reproducible when DEBUG macro is defined.