### PR TITLE
proc: fix MemAvailable in /proc/meminfo to exclude tmpfs files

### DIFF
--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -1351,7 +1351,7 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 			snprintf(lbuf, 100, "MemFree:        %8" PRIu64 " kB\n", memlimit - memusage);
 			printme = lbuf;
 		} else if (startswith(line, "MemAvailable:")) {
-			snprintf(lbuf, 100, "MemAvailable:   %8" PRIu64 " kB\n", memlimit - memusage + mstat.total_cache / 1024);
+			snprintf(lbuf, 100, "MemAvailable:   %8" PRIu64 " kB\n", memlimit - memusage + (mstat.total_active_file + mstat.total_inactive_file) / 1024);
 			printme = lbuf;
 		} else if (startswith(line, "SwapTotal:")) {
 			if (wants_swap) {


### PR DESCRIPTION
The "total_cache" from memory.stat of cgroup includes the memory used by tmpfs files ("total_shmem"). Considering it as available memory is wrong because files created on a tmpfs file system cannot be simply reclaimed.

So the available memory is calculated with the sum of:
 * Memory the kernel knows is free
 * Memory that contained in the kernel active file LRU, that can be reclaimed if necessary
 * Memory that is contained in the kernel non-active file LRU, that can be reclaimed if necessary