### PR TITLE
systemd: mkdir -p the target mount dir

### DIFF
--- a/config/init/systemd/lxcfs.service.in
+++ b/config/init/systemd/lxcfs.service.in
@@ -6,6 +6,7 @@ Documentation=man:lxcfs(1)
 
 [Service]
 OOMScoreAdjust=-1000
+ExecStartPre=/bin/mkdir -p {{LXCFSTARGETDIR}}
 ExecStart=/usr/bin/lxcfs {{LXCFSTARGETDIR}}
 KillMode=process
 Restart=on-failure


### PR DESCRIPTION
This is probably in a postinst for a debian package or a snap somewhere, but we're repackaging it somewhere and I have an ugly sed to fix it up. Let's do it here instead.