### PR TITLE
Add macro pivot&bpf for loongarch64

### DIFF
--- a/src/syscall_numbers.h
+++ b/src/syscall_numbers.h
@@ -39,6 +39,8 @@
 		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
 			#define __NR_pivot_root 5151
 		#endif
+	#elif defined __loongarch64
+		#define __NR_pivot_root 41
 	#else
 		#define -1
 		#warning "__NR_pivot_root not defined for your architecture"
@@ -72,6 +74,8 @@
 		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
 			#define __NR_bpf 5315
 		#endif
+	#elif defined __loongarch64
+		#define __NR_bpf 280
 	#else
 		#define -1
 		#warning "__NR_bpf not defined for your architecture"


### PR DESCRIPTION

The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html