### PR TITLE
typofix: fix incorrect printing in lxcfs help interface

### DIFF
--- a/src/lxcfs.c
+++ b/src/lxcfs.c
@@ -1181,7 +1181,7 @@ static void usage(void)
 	lxcfs_info("Options :");
 	lxcfs_info("  -d, --debug          Run lxcfs with debugging enabled");
 	lxcfs_info("  -f, --foreground     Run lxcfs in the foreground");
-	lxcfs_info("  -n, --help           Print help");
+	lxcfs_info("  -h, --help           Print help");
 	lxcfs_info("  -l, --enable-loadavg Enable loadavg virtualization");
 	lxcfs_info("  -o                   Options to pass directly through fuse");
 	lxcfs_info("  -p, --pidfile=FILE   Path to use for storing lxcfs pid");


### PR DESCRIPTION
We occasionally found an error printing in the lxcfs help interface. In theory, -h was written incorrectly -n.

There is an exception error before modification
<img width="774" alt="image" src="https://github.com/lxc/lxcfs/assets/26273331/830d1212-60f4-428a-930d-829b43da7108">

After modification：
<img width="784" alt="image" src="https://github.com/lxc/lxcfs/assets/26273331/b8b8a2f0-546f-429b-8ac5-a3618bfd2762">

