### PR TITLE
Prevent mount hook failure if /sys is not mounted.

### DIFF
--- a/share/lxc.mount.hook.in
+++ b/share/lxc.mount.hook.in
@@ -25,7 +25,7 @@ fi
 
 # /sys/devices/system/cpu
 if [ -d {{LXCFSTARGETDIR}}/sys/devices/system/cpu ] ; then
-    if [ -f {{LXCFSTARGETDIR}}/sys/devices/system/cpu/uevent ]; then
+    if [ -f {{LXCFSTARGETDIR}}/sys/devices/system/cpu/uevent && -e "${LXC_ROOTFS_MOUNT}/sys/devices/system/cpu" ]; then
         mount -n --bind {{LXCFSTARGETDIR}}/sys/devices/system/cpu "${LXC_ROOTFS_MOUNT}/sys/devices/system/cpu"
     else
         for entry in {{LXCFSTARGETDIR}}/sys/devices/system/cpu/*; do


### PR DESCRIPTION
This patch fixes lxcfs failure when I don't want anything mounted in a container by placing 
```
lxc.mount.auto =
```
in the container's configuration file.

This should also fix https://github.com/lxc/lxcfs/issues/559