### PR TITLE
lxc.mount.hook: Skip cpu sysfs logic if missing target

### DIFF
--- a/share/lxc.mount.hook.in
+++ b/share/lxc.mount.hook.in
@@ -24,7 +24,7 @@ if [ -d {{LXCFSTARGETDIR}}/proc/ ]; then
 fi
 
 # /sys/devices/system/cpu
-if [ -d {{LXCFSTARGETDIR}}/sys/devices/system/cpu ] ; then
+if [ -d {{LXCFSTARGETDIR}}/sys/devices/system/cpu ] && [ -d "${LXC_ROOTFS_MOUNT}/sys/devices/system/cpu" ]; then
     if [ -f {{LXCFSTARGETDIR}}/sys/devices/system/cpu/uevent ]; then
         mount -n --bind {{LXCFSTARGETDIR}}/sys/devices/system/cpu "${LXC_ROOTFS_MOUNT}/sys/devices/system/cpu"
     else


### PR DESCRIPTION
Closes #625

Suggested-by: amateur80lvl