### PR TITLE
Fix lxcfs read null

### DIFF
--- a/src/lxcfs.c
+++ b/src/lxcfs.c
@@ -743,6 +743,9 @@ static int lxcfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 #endif
 {
 	int ret;
+	enum lxcfs_virt_t type;
+	
+	type = file_info_type(fi);
 
 	if (strcmp(path, "/") == 0) {
 		if (dir_filler(filler, buf, ".", 0) != 0 ||
@@ -755,21 +758,21 @@ static int lxcfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 		return 0;
 	}
 
-	if (cgroup_is_enabled && strncmp(path, "/cgroup", 7) == 0) {
+	if (cgroup_is_enabled && LXCFS_TYPE_CGROUP(type)) {
 		up_users();
 		ret = do_cg_readdir(path, buf, filler, offset, fi);
 		down_users();
 		return ret;
 	}
 
-	if (strcmp(path, "/proc") == 0) {
+	if (LXCFS_TYPE_PROC(type)) {
 		up_users();
 		ret = do_proc_readdir(path, buf, filler, offset, fi);
 		down_users();
 		return ret;
 	}
 
-	if (strncmp(path, "/sys", 4) == 0) {
+	if (LXCFS_TYPE_SYS(type)) {
 		up_users();
 		ret = do_sys_readdir(path, buf, filler, offset, fi);
 		down_users();
@@ -876,27 +879,33 @@ static int lxcfs_read(const char *path, char *buf, size_t size, off_t offset,
 		      struct fuse_file_info *fi)
 {
 	int ret;
+	enum lxcfs_virt_t type;
+	
+	type = file_info_type(fi);
 
-	if (cgroup_is_enabled && strncmp(path, "/cgroup", 7) == 0) {
+	if (cgroup_is_enabled && LXCFS_TYPE_CGROUP(type)) {
 		up_users();
 		ret = do_cg_read(path, buf, size, offset, fi);
 		down_users();
 		return ret;
 	}
 
-	if (strncmp(path, "/proc", 5) == 0) {
+	if (LXCFS_TYPE_PROC(type)) {
 		up_users();
 		ret = do_proc_read(path, buf, size, offset, fi);
 		down_users();
 		return ret;
 	}
 
-	if (strncmp(path, "/sys", 4) == 0) {
+	if (LXCFS_TYPE_SYS(type)) {
 		up_users();
 		ret = do_sys_read(path, buf, size, offset, fi);
 		down_users();
 		return ret;
 	}
+
+	lxcfs_error("unknown file type: path=%s, type=%d, fi->fh=%" PRIu64,
+		path, type, fi->fh); 
 
 	return -EINVAL;
 }
@@ -905,15 +914,18 @@ int lxcfs_write(const char *path, const char *buf, size_t size, off_t offset,
 		struct fuse_file_info *fi)
 {
 	int ret;
+	enum lxcfs_virt_t type;
+	
+	type = file_info_type(fi);
 
-	if (cgroup_is_enabled && strncmp(path, "/cgroup", 7) == 0) {
+	if (cgroup_is_enabled && LXCFS_TYPE_CGROUP(type)) {
 		up_users();
 		ret = do_cg_write(path, buf, size, offset, fi);
 		down_users();
 		return ret;
 	}
 
-	if (strncmp(path, "/sys", 4) == 0) {
+	if (LXCFS_TYPE_SYS(type)) {
 		up_users();
 		ret = do_sys_write(path, buf, size, offset, fi);
 		down_users();


### PR DESCRIPTION
We used the macros that were implemented for lxcfs_release() to fix the NULL path issue. This will replace the existing strcmp solution. 

These macros have already been merged into the main branch to resolve the lxcfs_release() issue. 

fix #635 