### PR TITLE
tests: live-upgrade test remove --enable-cgroup (stable-5.0)

### DIFF
--- a/tests/live-upgrade-test.sh.in
+++ b/tests/live-upgrade-test.sh.in
@@ -51,7 +51,7 @@ if [ -x ${lxcfs} ]; then
 		export LD_LIBRARY_PATH="{{LXCFS_BUILD_ROOT}}"
 	fi
 	echo "=> Spawning ${lxcfs} ${LXCFSDIR}"
-	${lxcfs} --enable-cgroup -p ${pidfile} ${LXCFSDIR} &
+	${lxcfs} -p ${pidfile} ${LXCFSDIR} &
 	LXCFSPID=$!
 else
 	UNSHARE=0


### PR DESCRIPTION
--enable-cgroup has appeared in 6.0