### PR TITLE
lxcfs: fix readdir for procfs subtree

### DIFF
--- a/src/lxcfs.c
+++ b/src/lxcfs.c
@@ -747,7 +747,7 @@ static int lxcfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 {
 	int ret;
 	enum lxcfs_virt_t type;
-	
+
 	type = file_info_type(fi);
 
 	if (strcmp(path, "/") == 0) {
@@ -768,7 +768,7 @@ static int lxcfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 		return ret;
 	}
 
-	if (LXCFS_TYPE_PROC(type)) {
+	if (strcmp(path, "/proc") == 0) {
 		up_users();
 		ret = do_proc_readdir(path, buf, filler, offset, fi);
 		down_users();
@@ -883,7 +883,7 @@ static int lxcfs_read(const char *path, char *buf, size_t size, off_t offset,
 {
 	int ret;
 	enum lxcfs_virt_t type;
-	
+
 	type = file_info_type(fi);
 
 	if (cgroup_is_enabled && LXCFS_TYPE_CGROUP(type)) {
@@ -908,7 +908,7 @@ static int lxcfs_read(const char *path, char *buf, size_t size, off_t offset,
 	}
 
 	lxcfs_error("unknown file type: path=%s, type=%d, fi->fh=%" PRIu64,
-		path, type, fi->fh); 
+		path, type, fi->fh);
 
 	return -EINVAL;
 }
@@ -918,7 +918,7 @@ int lxcfs_write(const char *path, const char *buf, size_t size, off_t offset,
 {
 	int ret;
 	enum lxcfs_virt_t type;
-	
+
 	type = file_info_type(fi);
 
 	if (cgroup_is_enabled && LXCFS_TYPE_CGROUP(type)) {

--- a/tests/test_proc.in
+++ b/tests/test_proc.in
@@ -65,6 +65,13 @@ fi
 echo $((64*1024*1024)) > ${mempath}/lxcfs_test_proc/${memory_limit_file}
 echo 0 > ${cpupath}/lxcfs_test_proc/cpuset.cpus
 
+# Test that readdir on /proc basically works
+echo "==> Testing directory listing on /proc"
+ls -l ${LXCFSDIR}/proc | grep uptime
+ls -l ${LXCFSDIR}/proc | grep cpuinfo
+ls -l ${LXCFSDIR}/proc | grep stat
+ls -l ${LXCFSDIR}/proc | grep meminfo
+
 # Test uptime
 echo "==> Testing /proc/uptime"
 grep -Eq "^0.[0-9]{2} 0.[0-9]{2}$" ${LXCFSDIR}/proc/uptime


### PR DESCRIPTION
After #640 was merged we've got the entire
procfs subtree unavailable.

procfs can not be converted `LXCFS_TYPE_PROC` check in `readdir` because we don't have a designated `enum lxcfs_virt_t`-typed value for procfs directory. We can not introduce it too as it will break live upgrades of liblxcfs.

Fixes: #640