### PR TITLE
cgroups/cgfsng: improve swap accounting support detection

### DIFF
--- a/src/cgroups/cgroup_utils.h
+++ b/src/cgroups/cgroup_utils.h
@@ -80,6 +80,7 @@ extern char *cg_hybrid_get_current_cgroup(char *basecginfo,
 extern char *cg_legacy_get_current_cgroup(pid_t pid, const char *controller);
 extern bool mkdir_p(const char *dir, mode_t mode);
 extern bool is_cgroup_fd(int fd);
+extern bool is_cgroup2_fd(int fd);
 
 static inline int openat_safe(int fd, const char *path)
 {


### PR DESCRIPTION
When LXCFS daemon runs in a root cgroup of cgroup2 tree, we need to go down the tree when checking for memory.swap.current.

We already have some logic to go up the tree from LXCFS daemon's cgroup, but it's useless when LXCFS daemon sits in the cgroup2 tree root.