### PR TITLE
feat: add --force-render-cgroup args to make lxcfs render in view of specific cgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ The recommended command to run lxcfs is:
 A container runtime wishing to use `LXCFS` should then bind mount the
 approriate files into the correct places on container startup.
 
+### Overriding the cgroup used for virtualization
+
+When `LXCFS` can't resolve the calling process to the cgroup you want to
+virtualize against, you can pin virtualization to a specific cgroup path:
+
+    sudo lxcfs --cgroup-override=/my-service.slice/my-cgroup /var/lib/lxcfs
+
+The override applies to procfs/sysfs virtualization and uses the provided
+cgroup path instead of resolving it from the caller's PID.
+
 ### LXC
 In order to use lxcfs with systemd-based containers, you can either use
 LXC 1.1 in which case it should work automatically, or otherwise, copy

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -54,7 +54,7 @@ static bool has_versioned_opts;
 static bool memory_is_cgroupv2;
 static __u32 host_personality;
 static char runtime_path[PATH_MAX] = DEFAULT_RUNTIME_PATH;
-
+static char cgroup_override[PATH_MAX] = "";
 
 static volatile sig_atomic_t reload_successful;
 
@@ -567,6 +567,28 @@ pid_t lookup_initpid_in_store(pid_t pid)
 	return hashed_pid;
 }
 
+char *resolve_virtualized_cgroup(struct lxcfs_opts *opts,
+				 pid_t requester_pid,
+				 const char *controller)
+{
+	char *cgroup;
+	pid_t initpid;
+
+	if (opts && opts->version >= 5 && opts->cgroup_override[0])
+		return strdup(opts->cgroup_override);
+
+	initpid = lookup_initpid_in_store(requester_pid);
+	if (initpid <= 1 || is_shared_pidns(initpid))
+		initpid = requester_pid;
+
+	cgroup = get_pid_cgroup(initpid, controller);
+	if (!cgroup)
+		return NULL;
+
+	prune_init_slice(cgroup);
+	return cgroup;
+}
+
 /*
  * Functions needed to setup cgroups in the __constructor__.
  */
@@ -886,6 +908,18 @@ bool set_runtime_path(const char* new_path)
 	}
 }
 
+void set_cgroup_override(const char* new_path)
+{
+	if (new_path && strlen(new_path) < PATH_MAX) {
+		if (new_path[0]) {
+			strlcpy(cgroup_override, new_path, sizeof(cgroup_override));
+			lxcfs_info("Using cgroup override %s", cgroup_override);
+		}
+	} else {
+		lxcfs_error("%s\n", "Failed to overwrite the cgroup override");
+	}
+}
+
 void lxcfslib_init(void)
 {
 	__do_close int init_ns = -EBADF, root_fd = -EBADF,
@@ -1013,6 +1047,9 @@ void *lxcfs_fuse_init(struct fuse_conn_info *conn, void *data)
 	// We can read runtime_path as of opts version 2.
 	if (opts && opts->version >= 2) {
 		set_runtime_path(opts->runtime_path);
+	}
+	if (opts && opts->version >= 5) {
+		set_cgroup_override(opts->cgroup_override);
 	}
 
 	/* initialize the library */

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -145,6 +145,12 @@ struct lxcfs_opts {
 	char runtime_path[PATH_MAX];
 	bool zswap_off;
 	bool psi_poll_on;
+	/*
+	 * When set, all procfs/sysfs virtualization uses this cgroup path
+	 * instead of resolving it from the calling process's PID.
+	 * Added in opts version 5.
+	 */
+	char cgroup_override[PATH_MAX];
 };
 
 typedef enum lxcfs_opt_t {
@@ -167,6 +173,21 @@ extern bool liblxcfs_memory_is_cgroupv2(void);
 extern bool liblxcfs_can_use_sys_cpu(void);
 extern bool liblxcfs_has_versioned_opts(void);
 extern __u32 liblxcfs_personality(void);
+
+/*
+ * resolve_virtualized_cgroup - Resolve the cgroup path used for
+ * procfs/sysfs virtualization.
+ *
+ * If --cgroup-override is set, returns a copy of that override path.
+ * Otherwise, resolves the cgroup from the requester's effective init PID
+ * for the given controller and normalizes the result for virtualization.
+ *
+ * Returns a newly allocated string on success, NULL on failure.
+ * Caller must free the returned string.
+ */
+extern char *resolve_virtualized_cgroup(struct lxcfs_opts *opts,
+				        pid_t requester_pid,
+				        const char *controller);
 
 static inline bool lxcfs_has_opt(struct lxcfs_opts *opts, lxcfs_opt_t opt)
 {

--- a/src/lxcfs.c
+++ b/src/lxcfs.c
@@ -37,6 +37,7 @@
 
 void *dlopen_handle;
 static char runtime_path[PATH_MAX] = DEFAULT_RUNTIME_PATH;
+static char cgroup_override[PATH_MAX] = "";
 
 
 /* Functions to keep track of number of threads using the library */
@@ -754,6 +755,10 @@ static void usage(void)
 	lxcfs_info("  --enable-pidfd       Use pidfd for process tracking");
 	lxcfs_info("  --runtime-dir=DIR    Path to use as the runtime directory.");
 	lxcfs_info("                       Default is %s", DEFAULT_RUNTIME_PATH);
+	lxcfs_info("  --cgroup-override=CGROUP");
+	lxcfs_info("                       Override cgroup path for all procfs/sysfs");
+	lxcfs_info("                       virtualization instead of resolving it from");
+	lxcfs_info("                       the calling process's PID.");
 	exit(EXIT_FAILURE);
 }
 
@@ -804,6 +809,7 @@ static const struct option long_options[] = {
 	{"enable-cfs",		no_argument,		0,	  0	},
 	{"enable-pidfd",	no_argument,		0,	  0	},
 	{"enable-psi-poll",	no_argument,		0,	  0	},
+	{"cgroup-override",	required_argument,		0,	  0	},
 
 	{"pidfile",		required_argument,	0,	'p'	},
 	{"runtime-dir",		required_argument,	0,	  0	},
@@ -864,6 +870,7 @@ int main(int argc, char *argv[])
 	char *const *new_argv;
 	struct lxcfs_opts *opts;
 	char *runtime_path_arg = NULL;
+	char *cgroup_override_arg = NULL;
 
 	opts = malloc(sizeof(struct lxcfs_opts));
 	if (opts == NULL) {
@@ -876,7 +883,7 @@ int main(int argc, char *argv[])
 	opts->use_pidfd = true;
 	opts->use_cfs = false;
 	opts->psi_poll_on = false;
-	opts->version = 4;
+	opts->version = 5;
 
 	while ((c = getopt_long(argc, argv, "dulfhvso:p:", long_options, &idx)) != -1) {
 		switch (c) {
@@ -889,6 +896,8 @@ int main(int argc, char *argv[])
 				opts->psi_poll_on = true;
 			else if (strcmp(long_options[idx].name, "runtime-dir") == 0)
 				runtime_path_arg = optarg;
+			else if (strcmp(long_options[idx].name, "cgroup-override") == 0)
+				cgroup_override_arg = optarg;
 			else
 				usage();
 			break;
@@ -949,6 +958,11 @@ int main(int argc, char *argv[])
 		lxcfs_info("runtime path set to %s", runtime_path);
 	}
 	strlcpy(opts->runtime_path, runtime_path, sizeof(opts->runtime_path));
+	if (cgroup_override_arg) {
+		strlcpy(cgroup_override, cgroup_override_arg, sizeof(cgroup_override));
+		lxcfs_info("cgroup override set to %s", cgroup_override);
+	}
+	strlcpy(opts->cgroup_override, cgroup_override, sizeof(opts->cgroup_override));
 
 	fuse_argv[fuse_argc++] = argv[0];
 	if (debug)

--- a/src/proc_cpuview.c
+++ b/src/proc_cpuview.c
@@ -996,18 +996,13 @@ int proc_cpuinfo_read(char *buf, size_t size, off_t offset,
 	cache = d->buf;
 	cache_size = d->buflen;
 
-	pid_t initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cg = get_pid_cgroup(initpid, "cpuset");
+	cg = resolve_virtualized_cgroup(opts, fc->pid, "cpuset");
 	if (!cg)
 		return read_file_fuse("proc/cpuinfo", buf, size, d);
-	prune_init_slice(cg);
-	cpu_cg = get_pid_cgroup(initpid, "cpu");
+	cpu_cg = resolve_virtualized_cgroup(opts, fc->pid, "cpu");
 	if (!cpu_cg)
 		return read_file_fuse("proc/cpuinfo", buf, size, d);
-	prune_init_slice(cpu_cg);
+
 	cpuset = get_cpuset(cg);
 	if (!cpuset)
 		return 0;

--- a/src/proc_fuse.c
+++ b/src/proc_fuse.c
@@ -496,6 +496,7 @@ static int proc_swaps_read(char *buf, size_t size, off_t offset,
 	__do_free char *cgroup = NULL, *memusage_str = NULL,
 		 *memswusage_str = NULL, *memswpriority_str = NULL;
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	bool wants_swap = lxcfs_has_opt(fuse_get_context()->private_data, LXCFS_SWAP_ON);
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
 	uint64_t memlimit = 0, memusage = 0,
@@ -526,14 +527,9 @@ static int proc_swaps_read(char *buf, size_t size, off_t offset,
 		return total_len;
 	}
 
-	pid_t initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cgroup = get_pid_cgroup(initpid, "memory");
+	cgroup = resolve_virtualized_cgroup(opts, fc->pid, "memory");
 	if (!cgroup)
 		return read_file_fuse("/proc/swaps", buf, size, d);
-	prune_init_slice(cgroup);
 
 	ret = get_min_memlimit(cgroup, false, &memlimit);
 	if (ret < 0)
@@ -654,6 +650,7 @@ static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 	__do_free void *fopen_cache = NULL;
 	__do_fclose FILE *f = NULL;
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
 	struct lxcfs_diskstats stats = {};
 	/* helper fields */
@@ -687,14 +684,9 @@ static int proc_diskstats_read(char *buf, size_t size, off_t offset,
 	cache = d->buf;
 	cache_size = d->buflen;
 
-	pid_t initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cg = get_pid_cgroup(initpid, "blkio");
+	cg = resolve_virtualized_cgroup(opts, fc->pid, "blkio");
 	if (!cg)
 		return read_file_fuse("/proc/diskstats", buf, size, d);
-	prune_init_slice(cg);
 
 	ret = cgroup_ops->get_io_serviced(cgroup_ops, cg, &io_serviced_str);
 	if (ret < 0) {
@@ -864,18 +856,14 @@ static inline void iwashere(void)
  */
 static double get_reaper_busy(pid_t task)
 {
+	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	__do_free char *cgroup = NULL, *usage_str = NULL;
 	uint64_t usage = 0;
-	pid_t initpid;
 
-	initpid = lookup_initpid_in_store(task);
-	if (initpid <= 0)
-		return 0;
-
-	cgroup = get_pid_cgroup(initpid, "cpuacct");
+	cgroup = resolve_virtualized_cgroup(opts, fc->pid, "cpuacct");
 	if (!cgroup)
 		return 0;
-	prune_init_slice(cgroup);
 
 	if (!cgroup_ops->get(cgroup_ops, "cpuacct", cgroup, "cpuacct.usage", &usage_str))
 		return 0;
@@ -1095,26 +1083,26 @@ static int proc_stat_read(char *buf, size_t size, off_t offset,
 	cache = d->buf + CPUALL_MAX_SIZE;
 	cache_size = d->buflen - CPUALL_MAX_SIZE;
 
-	pid_t initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
+	if (!(opts && opts->version >= 5 && opts->cgroup_override[0])) {
+		/*
+		 * when container run with host pid namespace initpid == 1, cgroup will "/"
+		 * we should return host os's /proc contents.
+		 * in some case cpuacct_usage.all in "/" will larger then /proc/stat
+		 */
+		pid_t initpid = lookup_initpid_in_store(fc->pid);
+		if (initpid <= 1 || is_shared_pidns(initpid))
+			initpid = fc->pid;
+		if (initpid == 1)
+			return read_file_fuse("/proc/stat", buf, size, d);
+	}
 
-	/*
-	 * when container run with host pid namespace initpid == 1, cgroup will "/"
-	 * we should return host os's /proc contents.
-	 * in some case cpuacct_usage.all in "/" will larger then /proc/stat
-	 */
-	if (initpid == 1)
-		return read_file_fuse("/proc/stat", buf, size, d);
-
-	cg = get_pid_cgroup(initpid, "cpuset");
+	cg = resolve_virtualized_cgroup(opts, fc->pid, "cpuset");
 	if (!cg)
 		return read_file_fuse("/proc/stat", buf, size, d);
-	prune_init_slice(cg);
-	cpu_cg = get_pid_cgroup(initpid, "cpu");
+	cpu_cg = resolve_virtualized_cgroup(opts, fc->pid, "cpu");
 	if (!cpu_cg)
 		return read_file_fuse("/proc/stat", buf, size, d);
-	prune_init_slice(cpu_cg);
+
 	cpuset = get_cpuset(cg);
 	if (!cpuset)
 		return 0;
@@ -1409,6 +1397,7 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 	__do_free void *fopen_cache = NULL;
 	__do_fclose FILE *f = NULL;
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	bool wants_swap = lxcfs_has_opt(fuse_get_context()->private_data, LXCFS_SWAP_ON);
 	bool wants_zswap = lxcfs_has_opt(fuse_get_context()->private_data, LXCFS_ZSWAP_ON);
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
@@ -1443,15 +1432,9 @@ static int proc_meminfo_read(char *buf, size_t size, off_t offset,
 	cache = d->buf;
 	cache_size = d->buflen;
 
-	pid_t initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cgroup = get_pid_cgroup(initpid, "memory");
+	cgroup = resolve_virtualized_cgroup(opts, fc->pid, "memory");
 	if (!cgroup)
 		return read_file_fuse("/proc/meminfo", buf, size, d);
-
-	prune_init_slice(cgroup);
 
 	/* memory limits */
 	ret = cgroup_ops->get_memory_current(cgroup_ops, cgroup, &memusage_str);
@@ -1654,11 +1637,11 @@ static int proc_slabinfo_read(char *buf, size_t size, off_t offset,
 	__do_fclose FILE *f = NULL;
 	__do_close int fd = -EBADF;
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
 	size_t linelen = 0, total_len = 0;
 	char *cache;
 	size_t cache_size;
-	pid_t initpid;
 
 	if (offset) {
 		size_t left;
@@ -1682,15 +1665,9 @@ static int proc_slabinfo_read(char *buf, size_t size, off_t offset,
 	cache = d->buf;
 	cache_size = d->buflen;
 
-	initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cgroup = get_pid_cgroup(initpid, "memory");
+	cgroup = resolve_virtualized_cgroup(opts, fc->pid, "memory");
 	if (!cgroup)
 		return read_file_fuse("/proc/slabinfo", buf, size, d);
-
-	prune_init_slice(cgroup);
 
 	fd = cgroup_ops->get_memory_slabinfo_fd(cgroup_ops, cgroup);
 	if (fd < 0)
@@ -1729,6 +1706,7 @@ static int proc_pressure_read(char *buf, size_t size, off_t offset,
 	__do_fclose FILE *f = NULL;
 	__do_close int fd = -EBADF;
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
 	size_t linelen = 0, total_len = 0;
 	char *cache;
@@ -1736,7 +1714,6 @@ static int proc_pressure_read(char *buf, size_t size, off_t offset,
 	char *fallback_path;
 	char *controller;
 	int (*get_pressure_fd)(struct cgroup_ops *ops, const char *cgroup);
-	pid_t initpid;
 
 	if (offset) {
 		size_t left;
@@ -1780,15 +1757,9 @@ static int proc_pressure_read(char *buf, size_t size, off_t offset,
 	cache = d->buf;
 	cache_size = d->buflen;
 
-	initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cgroup = get_pid_cgroup(initpid, controller);
+	cgroup = resolve_virtualized_cgroup(opts, fc->pid, controller);
 	if (!cgroup)
 		return read_file_fuse(fallback_path, buf, size, d);
-
-	prune_init_slice(cgroup);
 
 	fd = get_pressure_fd(cgroup_ops, cgroup);
 	if (fd < 0)
@@ -1967,6 +1938,7 @@ static int proc_psi_trigger_write(const char *path, const char *buf, size_t size
 				off_t offset, struct fuse_file_info *fi)
 {
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = fc->private_data;
 	bool psi_virtualization_enabled = lxcfs_has_opt(fc->private_data, LXCFS_PSI_POLL_ON);
 	struct file_info *f = INTTYPE_TO_PTR(fi->fh);
 	__do_free psi_trigger_t *t = NULL;
@@ -1974,7 +1946,6 @@ static int proc_psi_trigger_write(const char *path, const char *buf, size_t size
 	__do_close int fd = -EBADF;
 	char *controller;
 	int (*get_pressure_fd)(struct cgroup_ops *ops, const char *cgroup);
-	pid_t initpid;
 	char tmpbuf[32];
 	size_t tmpbuf_size;
 	bool psi_full;
@@ -2050,15 +2021,9 @@ static int proc_psi_trigger_write(const char *path, const char *buf, size_t size
 		return -EINVAL;
 	}
 
-	initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cgroup = get_pid_cgroup(initpid, controller);
+	cgroup = resolve_virtualized_cgroup(opts, fc->pid, controller);
 	if (!cgroup)
 		return -EIO;
-
-	prune_init_slice(cgroup);
 
 	fd = get_pressure_fd(cgroup_ops, cgroup);
 	if (fd < 0)

--- a/src/proc_loadavg.c
+++ b/src/proc_loadavg.c
@@ -190,8 +190,8 @@ int proc_loadavg_read(char *buf, size_t size, off_t offset,
 {
 	__do_free char *cg = NULL;
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
-	pid_t initpid;
 	ssize_t total_len = 0;
 	struct load_node *n;
 	int hash;
@@ -216,15 +216,10 @@ int proc_loadavg_read(char *buf, size_t size, off_t offset,
 	if (!loadavg)
 		return read_file_fuse("/proc/loadavg", buf, size, d);
 
-	initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cg = get_pid_cgroup(initpid, "cpu");
+	cg = resolve_virtualized_cgroup(opts, fc->pid, "cpu");
 	if (!cg)
 		return read_file_fuse("/proc/loadavg", buf, size, d);
 
-	prune_init_slice(cg);
 	hash = calc_hash(cg) % LOAD_SIZE;
 	n = locate_node(cg, hash);
 
@@ -247,7 +242,7 @@ int proc_loadavg_read(char *buf, size_t size, off_t offset,
 		n->avenrun[2] = 0;
 		n->run_pid = 0;
 		n->total_pid = 1;
-		n->last_pid = initpid;
+		n->last_pid = fc->pid;
 		n->cfd = cfd;
 		pthread_rwlock_unlock(&load_hash[hash].rdlock);
 		insert_node(&n, hash);

--- a/src/sysfs_fuse.c
+++ b/src/sysfs_fuse.c
@@ -79,9 +79,9 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 {
 	__do_free char *cg = NULL, *cpu_cg = NULL;
 	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
 	struct file_info *d = INTTYPE_TO_PTR(fi->fh);
 	char *cache = d->buf;
-	pid_t initpid;
 	ssize_t total_len = 0;
 
 	if (offset) {
@@ -100,18 +100,13 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 		return total_len;
 	}
 
-	initpid = lookup_initpid_in_store(fc->pid);
-	if (initpid <= 1 || is_shared_pidns(initpid))
-		initpid = fc->pid;
-
-	cg = get_pid_cgroup(initpid, "cpuset");
+	cg = resolve_virtualized_cgroup(opts, fc->pid, "cpuset");
 	if (!cg)
 		return read_file_fuse("/sys/devices/system/cpu/online", buf, size, d);
-	prune_init_slice(cg);
-	cpu_cg = get_pid_cgroup(initpid, "cpu");
+	cpu_cg = resolve_virtualized_cgroup(opts, fc->pid, "cpu");
 	if (!cpu_cg)
 		return read_file_fuse("/sys/devices/system/cpu/online", buf, size, d);
-	prune_init_slice(cpu_cg);
+
 	total_len = do_cpuset_read(cg, cpu_cg, d->buf, d->buflen);
 
 	d->size = (int)total_len;
@@ -127,26 +122,20 @@ static int sys_devices_system_cpu_online_read(char *buf, size_t size,
 
 static int sys_devices_system_cpu_online_getsize(const char *path)
 {
-        __do_free char *cg = NULL, *cpu_cg = NULL;
-        struct fuse_context *fc = fuse_get_context();
-        pid_t initpid;
-        char buf[BUF_RESERVE_SIZE];
-        int buflen = sizeof(buf);
+	__do_free char *cg = NULL, *cpu_cg = NULL;
+	struct fuse_context *fc = fuse_get_context();
+	struct lxcfs_opts *opts = (struct lxcfs_opts *)fc->private_data;
+	char buf[BUF_RESERVE_SIZE];
+	int buflen = sizeof(buf);
 
-        initpid = lookup_initpid_in_store(fc->pid);
-        if (initpid <= 1 || is_shared_pidns(initpid))
-                initpid = fc->pid;
+	cg = resolve_virtualized_cgroup(opts, fc->pid, "cpuset");
+	if (!cg)
+		return get_sysfile_size(path);
+	cpu_cg = resolve_virtualized_cgroup(opts, fc->pid, "cpu");
+	if (!cpu_cg)
+		return get_sysfile_size(path);
 
-        cg = get_pid_cgroup(initpid, "cpuset");
-        if (!cg)
-                return get_sysfile_size(path);
-        cpu_cg = get_pid_cgroup(initpid, "cpu");
-        if (!cpu_cg)
-                return get_sysfile_size(path);
-        prune_init_slice(cg);
-        prune_init_slice(cpu_cg);
-
-        return do_cpuset_read(cg, cpu_cg, buf, buflen);
+	return do_cpuset_read(cg, cpu_cg, buf, buflen);
 }
 
 static int filler_sys_devices_system_cpu(const char *path, void *buf,

--- a/tests/test_proc.in
+++ b/tests/test_proc.in
@@ -5,9 +5,54 @@ set -eu
 [ -n "${DEBUG:-}" ] && set -x
 
 PASS=0
+OVERRIDE_LXCFSDIR=
+OVERRIDE_PIDFILE=
+OVERRIDE_LXCFSPID=
 
 cleanup() {
+    if [ -n "${OVERRIDE_LXCFSPID}" ]; then
+        kill -9 ${OVERRIDE_LXCFSPID} 2>/dev/null || true
+    fi
+    if [ -n "${OVERRIDE_LXCFSDIR}" ] && mountpoint -q ${OVERRIDE_LXCFSDIR}; then
+        umount -l ${OVERRIDE_LXCFSDIR} 2>/dev/null || true
+    fi
+    if [ -n "${OVERRIDE_LXCFSDIR}" ]; then
+        rmdir ${OVERRIDE_LXCFSDIR} 2>/dev/null || true
+    fi
+    if [ -n "${OVERRIDE_PIDFILE}" ]; then
+        rm -f ${OVERRIDE_PIDFILE}
+    fi
     [ "$PASS" = "1" ] || (echo FAIL && exit 1)
+}
+
+join_cgroup_path() {
+    base=$1
+    child=$2
+
+    if [ "${base}" = "/" ]; then
+        printf '/%s' "${child}"
+    else
+        printf '%s/%s' "${base}" "${child}"
+    fi
+}
+
+spawn_override_lxcfs() {
+    override_cgroup=$1
+    count=1
+
+    OVERRIDE_LXCFSDIR=$(mktemp -d)
+    OVERRIDE_PIDFILE=$(mktemp)
+    {{LXCFS_BUILD_ROOT}}/lxcfs -f --enable-psi-poll --cgroup-override "${override_cgroup}" -p ${OVERRIDE_PIDFILE} ${OVERRIDE_LXCFSDIR} &
+    OVERRIDE_LXCFSPID=$!
+
+    while ! mountpoint -q ${OVERRIDE_LXCFSDIR}; do
+        sleep 1
+        if [ ${count} -gt 5 ]; then
+            echo "override lxcfs failed to start"
+            exit 1
+        fi
+        count=$((count + 1))
+    done
 }
 
 trap cleanup EXIT HUP INT TERM
@@ -30,12 +75,16 @@ mempath=${hierarchy_path}
 
 rmdir ${hierarchy_path}/lxcfs_test_proc 2>/dev/null || true
 mkdir ${hierarchy_path}/lxcfs_test_proc
+rmdir ${hierarchy_path}/lxcfs_test_proc_override 2>/dev/null || true
+mkdir ${hierarchy_path}/lxcfs_test_proc_override
+override_cgroup=/lxcfs_test_proc_override
 
 echo 1 > ${hierarchy_path}/lxcfs_test_proc/cgroup.procs
 
 echo '+cpu +cpuset +memory' > ${hierarchy_path}/cgroup.subtree_control
 
 echo $((64*1024*1024)) > ${mempath}/lxcfs_test_proc/memory.max
+echo $((32*1024*1024)) > ${mempath}/lxcfs_test_proc_override/memory.max
 echo 0 > ${cpupath}/lxcfs_test_proc/cpuset.cpus
 
 # Test that readdir on /proc basically works
@@ -82,6 +131,12 @@ done
 # Test meminfo
 echo "==> Testing /proc/meminfo"
 grep -q "^MemTotal.*65536 kB$" "${LXCFSDIR}"/proc/meminfo
+
+if [ -x {{LXCFS_BUILD_ROOT}}/lxcfs ]; then
+    echo "==> Testing --cgroup-override"
+    spawn_override_lxcfs "${override_cgroup}"
+    grep -q "^MemTotal.*32768 kB$" ${OVERRIDE_LXCFSDIR}/proc/meminfo
+fi
 
 # We don't support PSI triggers virtualization with old libfuse
 if [ "$LIBFUSE" != "fuse" ]; then


### PR DESCRIPTION
it's useful in some complex container hierarchy,
many container work in same parent cgroup for sharing resource (cpu and other)
but need inspect total usage of parent cgroup in single container