### PR TITLE
Fix "Write to cache was truncated" on long-running / high-core-count systems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,3 +102,48 @@ jobs:
 
           echo 1 | sudo tee /sys/fs/cgroup/cpuset/cgroup.clone_children || true
           sudo -E PATH="${PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" build/tests/live-upgrade-test.sh "${NEW_LXCFS_TREE}"
+
+  buffer-truncation-test:
+    name: Buffer truncation regression (issue 694)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq gcc libfuse3-dev meson pkg-config uuid-runtime
+
+      - name: Build with tiny buffer reserve
+        env:
+          CC: gcc
+        run: |
+          echo "::group::Building LXCFS with BUF_RESERVE_SIZE=16"
+
+          # Build with a deliberately tiny buffer reserve to force the
+          # realloc path.  Without the dynamic realloc fix, the existing
+          # tests will fail with "Write to cache was truncated".
+          meson setup build \
+              -Ddocs=false \
+              -Dtests=true \
+              -Dmocks=true \
+              -Dinit-script=systemd \
+              -Dprefix=/usr \
+              -Db_sanitize=address,undefined \
+              -Dc_args='-DBUF_RESERVE_SIZE=16'
+          meson compile -C build
+
+          echo "::endgroup::"
+
+      - name: Test
+        env:
+          CC: gcc
+          LIBFUSE: fuse3
+        run: |
+          echo "::group::Running the testsuite with tiny buffer"
+
+          echo 1 | sudo tee /sys/fs/cgroup/cpuset/cgroup.clone_children || true
+          sudo -E PATH="${PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" build/tests/main.sh
+
+          echo "::endgroup::"

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,6 +40,7 @@ extern int read_file_fuse(const char *path, char *buf, size_t size,
 			  struct file_info *d);
 extern int read_file_fuse_with_offset(const char *path, char *buf, size_t size,
 				      off_t offset, struct file_info *d);
+extern bool try_realloc_proc_buf(struct file_info *d, const char *path);
 extern void prune_init_slice(char *cg);
 extern int wait_for_pid(pid_t pid);
 

--- a/tests/test_proc.in
+++ b/tests/test_proc.in
@@ -88,6 +88,24 @@ echo "==> Testing /sys/devices/system/cpu/online"
 echo "==> Testing /proc/stat"
 [ "$(grep "^cpu" ${LXCFSDIR}/proc/stat | wc -l)" = "2" ]
 
+# Test stat integrity — verify the output is well-formed and never truncated.
+# This catches the bug reported in https://github.com/lxc/lxcfs/issues/694
+echo "==> Testing /proc/stat integrity"
+stat_content=$(cat ${LXCFSDIR}/proc/stat)
+# Must start with "cpu " aggregate line
+echo "$stat_content" | head -1 | grep -q "^cpu "
+# Must contain standard non-cpu lines (these appear after cpu lines)
+echo "$stat_content" | grep -q "^intr "
+echo "$stat_content" | grep -q "^ctxt "
+echo "$stat_content" | grep -q "^btime "
+echo "$stat_content" | grep -q "^processes "
+# Read /proc/stat repeatedly — must never return empty
+echo "==> Testing /proc/stat repeated reads"
+for i in $(seq 1 100); do
+    bytes=$(cat ${LXCFSDIR}/proc/stat | wc -c)
+    [ "$bytes" -gt 0 ] || (echo "FAIL: /proc/stat returned empty on read $i" && exit 1)
+done
+
 # Test meminfo
 echo "==> Testing /proc/meminfo"
 grep -q "^MemTotal.*65536 kB$" ${LXCFSDIR}/proc/meminfo


### PR DESCRIPTION
Fixes #694                                                                                                

## Summary
LXCFS allocates a fixed-size buffer when a proc file is first open()'ed, sized as get_procfile_size(path) + BUF_RESERVE_SIZE (512 bytes). On systems with many CPUs or after extended uptime, /proc/stat and other proc files grow as kernel counters gain digits and new IRQ lines appear. Once the content exceeds the buffer allocated at open time, the read handler logs "Write to cache was truncated" and returns incomplete data, breaking applications like Java and Cassandra etc. that parse /proc/stat at startup.

This fix addresses it by adding a shared try_realloc_proc_buf() helper in utils.c that, on each offset-0 read, checks whether the underlying proc file has grown beyond the current buffer and realloc()s with 2x headroom if needed. 
The offset > 0 path (serving cached data) is unchanged — it continues to use d->buf directly.

## Testing
1. Added /proc/stat integrity checks to test_proc.in: verifies all expected sections (cpu, intr, ctxt,
  btime, processes) are present and that 100 consecutive reads never return empty.
 2. Added a buffer-truncation-test CI job that builds with -DBUF_RESERVE_SIZE=16 to force the realloc path
  on every read. Without this fix, the existing test suite fails with truncation errors under that
  configuration
