### PR TITLE
cgroups/cgfsng: check memory allocation in add_hierarchy

### DIFF
--- a/src/cgroups/cgfsng.c
+++ b/src/cgroups/cgfsng.c
@@ -285,7 +285,8 @@ static struct hierarchy *add_hierarchy(struct hierarchy ***h, char **clist, char
 	struct hierarchy *new;
 	int newentry;
 
-	new = zalloc(sizeof(*new));
+	new = must_realloc(NULL, sizeof(*new));
+	memset(new, 0, sizeof(*new));
 	new->controllers = clist;
 	new->mountpoint = mountpoint;
 	new->base_path = base_path;


### PR DESCRIPTION
Switch to must_realloc() to exclude the possibility of NULL ptr dereference. This codepath is safe to use must_*() functions.

Fixes: Coverity 501622